### PR TITLE
fix restore to use draft filing

### DIFF
--- a/src/components/bcros/filing/addStaffFiling/Index.vue
+++ b/src/components/bcros/filing/addStaffFiling/Index.vue
@@ -28,7 +28,8 @@ const restoreCompany = async (restorationType: FilingSubTypeE = null) => {
   const response: any = await filings.createFiling(
     currentBusiness.value,
     FilingTypes.RESTORATION,
-    { type: restorationType }
+    { type: restorationType },
+    true
   )
 
   if (response.error?.value) {


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/23491

*Description of changes:*
Set restoration filing type to draft (we were already using null and it works fine once the filing is draft)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
