### PR TITLE
Bug fix - Pending staff filings in to-do

### DIFF
--- a/cypress/e2e/components/todos/pending.cy.ts
+++ b/cypress/e2e/components/todos/pending.cy.ts
@@ -127,7 +127,7 @@ context('TODOs -> Pending Filing', () => {
     // this is to reproduce the scenario for ticket #23634
     // when the registrar's notation filing is pending and has not been added to the filing history yet.
 
-    // load the page with non-staff account; in the expanded content
+    // load the page with non-staff account
     cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, 'pendingRegistrarsNotation.json')
 
     cy.get('[data-cy^="todoItem-showMore-"]').click()

--- a/cypress/e2e/components/todos/pending.cy.ts
+++ b/cypress/e2e/components/todos/pending.cy.ts
@@ -87,6 +87,80 @@ context('TODOs -> Pending Filing', () => {
       .should('have.text', 'Change Payment Type')
   })
 
+  it('Test pending filing to-do item - registrar\'s notation filing is pending - staff account view', () => {
+    // this is to reproduce the scenario for ticket #23634
+    // when the registrar's notation filing is pending and has not been added to the filing history yet.
+
+    // laod the page with staff account
+    cy.visitBusinessDashFor(
+      'businessInfo/ben/active.json', undefined, false, false, 'pendingRegistrarsNotation.json', [], true
+    )
+
+    cy.get('[data-cy="header_todo"]').should('exist')
+    cy.get('[data-cy="todoItemList"]').should('exist')
+
+    // subtitle
+    cy.get('[data-cy^="todoItem-label-"]')
+      .should('exist')
+      .should('contains.text', 'Registrar\'s Notation')
+      .should('contains.text', 'FILING PENDING')
+      .should('contains.text', 'PAYMENT COMPLETED')
+
+    // View More button exists
+    cy.get('[data-cy^="todoItem-showMore-"]').should('exist')
+    cy.get('[data-cy^="todoItem-showMore-"]').click()
+
+    // Verify the expanded content
+    cy.get('[data-cy="todoItem-content"]')
+      .should('exist')
+      .should('contains.text', 'Paid')
+      .should('contains.text', 'This filing is paid but the filing is not yet complete. Please check again later.')
+
+    // staff account user should not see the contact info
+    cy.get('[data-cy="contact-info"]').should('not.exist')
+
+    // no action button
+    cy.get('[data-cy^="todoItemActions-"]').find('button').should('not.exist')
+  })
+
+  it('Test pending filing to-do item - registrar\'s notation filing is pending - non-staff account view', () => {
+    // this is to reproduce the scenario for ticket #23634
+    // when the registrar's notation filing is pending and has not been added to the filing history yet.
+
+    // load the page with non-staff account; in the expanded content
+    cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, 'pendingRegistrarsNotation.json')
+
+    cy.get('[data-cy^="todoItem-showMore-"]').click()
+
+    // Verify the expanded content; the contact info should be displayed
+    cy.get('[data-cy="todoItem-content"]')
+      .should('contains.text', 'If this error persists, please contact us')
+      .get('[data-cy="contact-info"]').should('exist')
+  })
+
+  it('Test pending filing to-do item - admin-freeze filing is pending', () => {
+    // this is to reproduce the scenario for ticket #23495
+    // when the admin freeze filing is pending and has not been added to the filing history yet.
+
+    cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, 'pendingAdminFreeze.json')
+
+    cy.get('[data-cy="header_todo"]').should('exist')
+    cy.get('[data-cy="todoItemList"]').should('exist')
+
+    // subtitle
+    cy.get('[data-cy^="todoItem-label-"]')
+      .should('exist')
+      .should('contains.text', 'Freeze Business')
+      .should('contains.text', 'FILING PENDING')
+      .should('contains.text', 'PAYMENT COMPLETED')
+
+    // View More button exists
+    cy.get('[data-cy^="todoItem-showMore-"]').should('exist')
+
+    // no action button
+    cy.get('[data-cy^="todoItemActions-"]').find('button').should('not.exist')
+  })
+
   it('Cancel Payment button is working', () => {
     cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, 'pendingPayment.json')
 

--- a/cypress/fixtures/todos/pendingAdminFreeze.json
+++ b/cypress/fixtures/todos/pendingAdminFreeze.json
@@ -1,0 +1,38 @@
+{
+  "tasks": [
+    {
+      "enabled": true,
+      "order": 1,
+      "task": {
+        "filing": {
+          "business": {
+            "foundingDate": "2024-10-12T00:27:29.366345+00:00",
+            "identifier": "BC0883617",
+            "legalName": "0883617 B.C. LTD.",
+            "legalType": "BC"
+          },
+          "header": {
+            "affectedFilings": [],
+            "availableOnPaperOnly": false,
+            "certifiedBy": "",
+            "colinIds": [],
+            "comments": [],
+            "date": "2024-10-25T00:04:54.570499+00:00",
+            "deletionLocked": false,
+            "documentOptionalEmail": "peinan.wang@gov.bc.ca",
+            "effectiveDate": "2024-10-25T00:04:54.570521+00:00",
+            "filingId": 151624,
+            "inColinOnly": false,
+            "isCorrected": false,
+            "isCorrectionPending": false,
+            "isFutureEffective": false,
+            "name": "adminFreeze",
+            "paymentStatusCode": "COMPLETED",
+            "status": "PENDING",
+            "submitter": "pewang@idir"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/todos/pendingRegistrarsNotation.json
+++ b/cypress/fixtures/todos/pendingRegistrarsNotation.json
@@ -1,0 +1,38 @@
+{
+  "tasks": [
+    {
+      "enabled": true,
+      "order": 1,
+      "task": {
+        "filing": {
+          "business": {
+            "foundingDate": "2024-10-12T00:27:29.366345+00:00",
+            "identifier": "BC0883617",
+            "legalName": "0883617 B.C. LTD.",
+            "legalType": "BC"
+          },
+          "header": {
+            "affectedFilings": [],
+            "availableOnPaperOnly": false,
+            "certifiedBy": "",
+            "colinIds": [],
+            "comments": [],
+            "date": "2024-10-25T00:04:54.570499+00:00",
+            "deletionLocked": false,
+            "documentOptionalEmail": "peinan.wang@gov.bc.ca",
+            "effectiveDate": "2024-10-25T00:04:54.570521+00:00",
+            "filingId": 151624,
+            "inColinOnly": false,
+            "isCorrected": false,
+            "isCorrectionPending": false,
+            "isFutureEffective": false,
+            "name": "registrarsNotation",
+            "paymentStatusCode": "COMPLETED",
+            "status": "PENDING",
+            "submitter": "pewang@idir"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/utils/todo/task-filing/content-loader.ts
+++ b/src/utils/todo/task-filing/content-loader.ts
@@ -74,7 +74,7 @@ export const getTitle = (filing: TaskToDoI, corpFullDescription: string): string
       title += filingTypeToName(FilingTypes.SPECIAL_RESOLUTION)
       return title
     default:
-      return title
+      return filingTypeToName(header.name)
   }
 }
 
@@ -121,7 +121,7 @@ export const getDraftTitle = (filing: TaskToDoI): string => {
     case FilingTypes.SPECIAL_RESOLUTION:
       return filingTypeToName(FilingTypes.SPECIAL_RESOLUTION)
     default:
-      return ''
+      return filingTypeToName(header.name)
   }
 }
 
@@ -205,7 +205,7 @@ export const addExpansionContent = (todoItem: TodoItemI): void => {
   } else if (todoItem.status === FilingStatusE.ERROR) {
     // if the filing has the error status
     todoItem.expansionContent = TodoExpansionContentE.PAYMENT_ERROR
-  } else if (todoItem.status === FilingStatusE.PAID) {
+  } else if (todoItem.status === FilingStatusE.PAID || todoItem.isPayCompleted) {
     // if the filing has the paid status
     todoItem.expansionContent = TodoExpansionContentE.PAID
   }


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/23495
*Issue:*https://github.com/bcgov/entity/issues/23634

*Description of changes:*
This bug is hard to reproduce as a staff filing does not get the pending status very often. To verify the bug has been resolved, pending filings are mocked in cypress test. The following screenshots are taken locally:

Pending Admin Freeze:
<img width="900" alt="Pending AdminFreeze" src="https://github.com/user-attachments/assets/d954c13d-ef4d-4b91-8cf4-bd6bff641de2">

Pending Registrar's Notation - Collapsed:
<img width="900" alt="RegistrarsNotation" src="https://github.com/user-attachments/assets/c3f6f5d7-a725-47ae-885a-1c142381849b">


Pending Registrar's Notation - Expanded (staff account users will not see the contact info section)
<img width="900" alt="RegistrarsNotation_expanded_staff" src="https://github.com/user-attachments/assets/06a94cf6-034d-4436-a146-712f51eb342f">

Pending Registrar's Notation - Expanded (non-staff users can see the contact info section)
<img width="900" alt="RegistrarsNotation_expanded_non_staff" src="https://github.com/user-attachments/assets/dbf24eca-fc80-4314-bbd1-83b069255020">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
