### PR TITLE
Bug fix - mismatches in the staff filing dropdown menu

### DIFF
--- a/cypress/e2e/components/filings/addStaffFiling.cy.ts
+++ b/cypress/e2e/components/filings/addStaffFiling.cy.ts
@@ -13,7 +13,7 @@ context('Add Staff Filing', () => {
     cy.get('[data-cy="add-staff-filing"]').should('not.exist')
   })
 
-  it('Staff should see menu', () => {
+  it('Menu options are rendered - active BEN company', () => {
     cy.fixture('comments/businessComments.json').then((response) => {
       cy.intercept(
         'GET',
@@ -23,11 +23,57 @@ context('Add Staff Filing', () => {
     cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, undefined, allFilings, true)
     // cy.wait(5000)
     cy.get('[data-cy="add-staff-filing"]').should('exist').click()
-    cy.get('[data-cy="admin-freeze"]').should('exist')
-    cy.get('[data-cy="dissolution"]').should('exist')
-    cy.get('[data-cy="registrar-notation"]').should('exist')
-    cy.get('[data-cy="registrar-order"]').should('exist')
-    cy.get('[data-cy="court-order"]').should('exist')
+    cy.get('[data-cy="admin-freeze"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="dissolution"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="registrar-notation"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="registrar-order"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="court-order"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="record-conversion"]').should('not.exist')
+    cy.get('[data-cy="restore"]').should('not.exist')
+    cy.get('[data-cy="put-back-on"]').should('not.exist')
+  })
+
+  it('Menu options are rendered - active SP company', () => {
+    cy.fixture('comments/businessComments.json').then((response) => {
+      cy.intercept(
+        'GET',
+        '**/api/v2/businesses/**/comments',
+        response).as('businessComments')
+    })
+    cy.visitBusinessDashFor('businessInfo/sp/active.json', undefined, false, false, undefined, allFilings, true)
+    // cy.wait(5000)
+    cy.get('[data-cy="add-staff-filing"]').should('exist').click()
+    cy.get('[data-cy="admin-freeze"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="dissolution"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="registrar-notation"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="registrar-order"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="court-order"]').should('exist').should('not.be.disabled')
+
+    // record conversion only visible for SP and GP
+    cy.get('[data-cy="record-conversion"]').should('exist').should('not.be.disabled')
+
+    cy.get('[data-cy="restore"]').should('not.exist')
+    cy.get('[data-cy="put-back-on"]').should('not.exist')
+  })
+
+  it('Menu options are rendered - historical business', () => {
+    cy.fixture('comments/businessComments.json').then((response) => {
+      cy.intercept(
+        'GET',
+        '**/api/v2/businesses/**/comments',
+        response).as('businessComments')
+    })
+    cy.visitBusinessDashFor('businessInfo/bc/historical.json', undefined, false, false, undefined, allFilings, true)
+    // cy.wait(5000)
+    cy.get('[data-cy="add-staff-filing"]').should('exist').click()
+    cy.get('[data-cy="admin-freeze"]').should('not.exist')
+    cy.get('[data-cy="dissolution"]').should('not.exist')
+    cy.get('[data-cy="registrar-notation"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="registrar-order"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="court-order"]').should('exist').should('not.be.disabled')
+    cy.get('[data-cy="record-conversion"]').should('not.exist')
+    cy.get('[data-cy="restore"]').should('exist')
+    cy.get('[data-cy="put-back-on"]').should('exist').should('not.be.disabled')
   })
 
   it('Staff should be able to cancel filing', () => {

--- a/cypress/fixtures/businessInfo/bc/historical.json
+++ b/cypress/fixtures/businessInfo/bc/historical.json
@@ -10,34 +10,34 @@
             "displayName": "Court Order",
             "feeCode": "NOFEE",
             "name": "courtOrder"
-        },
-        {
+          },
+          {
             "displayName": "Correction - Put Back On",
             "feeCode": "NOFEE",
             "name": "putBackOn"
-        },
-        {
+          },
+          {
             "displayName": "Registrar's Notation",
             "feeCode": "NOFEE",
             "name": "registrarsNotation"
-        },
-        {
+          },
+          {
             "displayName": "Registrar's Order",
             "feeCode": "NOFEE",
             "name": "registrarsOrder"
-        },
-        {
+          },
+          {
             "displayName": "Full Restoration Application",
             "feeCode": "RESTF",
             "name": "restoration",
             "type": "fullRestoration"
-        },
-        {
+          },
+          {
             "displayName": "Limited Restoration Application",
             "feeCode": "RESTL",
             "name": "restoration",
             "type": "limitedRestoration"
-        }
+          }
         ]
       }
     },

--- a/cypress/fixtures/businessInfo/bc/historical.json
+++ b/cypress/fixtures/businessInfo/bc/historical.json
@@ -5,7 +5,40 @@
       "digitalBusinessCard": false,
       "filing": {
         "filingSubmissionLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/BC0814603/filings",
-        "filingTypes": []
+        "filingTypes": [
+          {
+            "displayName": "Court Order",
+            "feeCode": "NOFEE",
+            "name": "courtOrder"
+        },
+        {
+            "displayName": "Correction - Put Back On",
+            "feeCode": "NOFEE",
+            "name": "putBackOn"
+        },
+        {
+            "displayName": "Registrar's Notation",
+            "feeCode": "NOFEE",
+            "name": "registrarsNotation"
+        },
+        {
+            "displayName": "Registrar's Order",
+            "feeCode": "NOFEE",
+            "name": "registrarsOrder"
+        },
+        {
+            "displayName": "Full Restoration Application",
+            "feeCode": "RESTF",
+            "name": "restoration",
+            "type": "fullRestoration"
+        },
+        {
+            "displayName": "Limited Restoration Application",
+            "feeCode": "RESTL",
+            "name": "restoration",
+            "type": "limitedRestoration"
+        }
+        ]
       }
     },
     "alternateNames": [],

--- a/cypress/fixtures/businessInfo/sp/active.json
+++ b/cypress/fixtures/businessInfo/sp/active.json
@@ -7,15 +7,51 @@
         "filingSubmissionLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/FM1060270/filings",
         "filingTypes": [
           {
+            "displayName": "Admin Freeze",
+            "feeCode": "NOFEE",
+            "name": "adminFreeze"
+          },
+          {
             "displayName": "Change of Registration Application",
             "feeCode": "FMCHANGE",
             "name": "changeOfRegistration"
+          },
+          {
+            "displayName": "Record Conversion",
+            "feeCode": "FMCONV",
+            "name": "conversion"
+          },
+          {
+            "displayName": "Register Correction Application",
+            "feeCode": "FMCORR",
+            "name": "correction"
+          },
+          {
+            "displayName": "Court Order",
+            "feeCode": "NOFEE",
+            "name": "courtOrder"
           },
           {
             "displayName": "Statement of Dissolution",
             "feeCode": "DIS_VOL",
             "name": "dissolution",
             "type": "voluntary"
+          },
+          {
+            "displayName": "Statement of Dissolution",
+            "feeCode": "DIS_ADM",
+            "name": "dissolution",
+            "type": "administrative"
+          },
+          {
+            "displayName": "Registrar's Notation",
+            "feeCode": "NOFEE",
+            "name": "registrarsNotation"
+          },
+          {
+            "displayName": "Registrar's Order",
+            "feeCode": "NOFEE",
+            "name": "registrarsOrder"
           }
         ]
       }

--- a/src/components/bcros/filing/addStaffFiling/Index.vue
+++ b/src/components/bcros/filing/addStaffFiling/Index.vue
@@ -142,7 +142,7 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
     },
     { // <!-- Continue Out -->
       showButton: !isHistorical.value && showContinueOut.value,
-      disabled: !business.isAllowedToFile(FilingTypes.CONTINUATION_OUT),
+      disabled: !business.isAllowed(AllowableActionE.CONTINUATION_OUT),
       datacy: 'continue-out',
       label: t('label.filing.staffFilingOptions.continueOut'),
       click: () => {

--- a/src/components/bcros/filing/addStaffFiling/Index.vue
+++ b/src/components/bcros/filing/addStaffFiling/Index.vue
@@ -11,7 +11,7 @@ interface MenuActionItem extends DropdownItem {
 const filings = useBcrosFilings()
 const business = useBcrosBusiness()
 const {
-  currentBusiness, showAmalgamateOut, showConsentAmalgamationOut, showConsentContinueOut, showContinueOut
+  currentBusiness, showAmalgamateOut, showConsentAmalgamationOut, showConsentContinueOut, showContinueOut, isHistorical
 } = storeToRefs(business)
 const { goToBusinessDashboard, goToEditPage, goToCreatePage } = useBcrosNavigate()
 
@@ -54,29 +54,29 @@ const restoreCompany = async (restorationType: FilingSubTypeE = null) => {
 const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
   return [
     { // <!-- Registrar Notation -->
-      showButton: business.isAllowedToFile(FilingTypes.REGISTRARS_NOTATION),
-      disabled: false,
+      showButton: true,
+      disabled: !business.isAllowed(AllowableActionE.REGISTRARS_NOTATION),
       datacy: 'registrar-notation',
       label: t('label.filing.staffFilingOptions.registrarsNotation'),
       click: () => { openRegistrarNotationModal.value = true }
     },
     { // <!-- Registrar Order -->
-      showButton: business.isAllowedToFile(FilingTypes.REGISTRARS_ORDER),
-      disabled: false,
+      showButton: true,
+      disabled: !business.isAllowed(AllowableActionE.REGISTRARS_ORDER),
       datacy: 'registrar-order',
       label: t('label.filing.staffFilingOptions.registrarsOrder'),
       click: () => { openRegistrarOrderModal.value = true }
     },
     { // <!-- Court Order -->
-      showButton: business.isAllowedToFile(FilingTypes.COURT_ORDER),
-      disabled: false,
+      showButton: true,
+      disabled: !business.isAllowed(AllowableActionE.COURT_ORDER),
       datacy: 'court-order',
       label: t('label.filing.staffFilingOptions.courtOrder'),
       click: () => { openCourtOrderModal.value = true }
     },
     { // <!-- Record Conversion -->
       showButton: business.isEntityFirm(),
-      disabled: !business.isAllowedToFile(FilingTypes.CONSENT_CONTINUATION_OUT),
+      disabled: !business.isAllowed(AllowableActionE.RECORD_CONVERSION),
       datacy: 'record-conversion',
       label: t('label.filing.staffFilingOptions.recordConversion'),
       click: () => {
@@ -84,28 +84,28 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       }
     },
     { // <!-- Admin Dissolution -->
-      showButton: currentBusiness.value?.state !== BusinessStateE.HISTORICAL,
-      disabled: !business.isAllowedToFile(FilingTypes.DISSOLUTION),
+      showButton: !isHistorical.value,
+      disabled: !business.isAllowed(AllowableActionE.ADMINISTRATIVE_DISSOLUTION),
       datacy: 'dissolution',
       label: t('label.filing.staffFilingOptions.dissolution'),
       click: () => { openDissolutionModal.value = true }
     },
     { // <!-- Restore Company  -->
-      showButton: currentBusiness.value?.state === BusinessStateE.HISTORICAL,
-      disabled: !business.isAllowedToFile(FilingTypes.RESTORATION),
+      showButton: isHistorical.value,
+      disabled: !business.isAllowed(AllowableActionE.RESTORATION),
       datacy: 'restore',
       label: t('label.filing.staffFilingOptions.restoreCompany'),
       click: () => { restoreCompany() }
     },
     { // <!-- Put Back On -->
-      showButton: business.isAllowedToFile(FilingTypes.PUT_BACK_ON),
+      showButton: business.isAllowed(AllowableActionE.PUT_BACK_ON),
       disabled: false,
       datacy: 'put-back-on',
       label: t('label.filing.staffFilingOptions.putBackOn'),
       click: () => { openPutBackOnModal.value = true }
     },
     { // <!-- Admin Freeze/Unfreeze -->
-      showButton: business.isAllowedToFile(FilingTypes.ADMIN_FREEZE),
+      showButton: business.isAllowed(AllowableActionE.FREEZE_UNFREEZE),
       disabled: false,
       datacy: 'admin-freeze',
       label: !currentBusiness?.value?.adminFreeze
@@ -114,8 +114,8 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       click: () => { openFreezeUnfreezeModal.value = true }
     },
     { // <!-- Consent to Amalgamate Out -->
-      showButton: currentBusiness.value?.state !== BusinessStateE.HISTORICAL && showConsentAmalgamationOut.value,
-      disabled: !business.isAllowedToFile(FilingTypes.CONSENT_AMALGAMATION_OUT),
+      showButton: !isHistorical.value && showConsentAmalgamationOut.value,
+      disabled: !business.isAllowed(AllowableActionE.CONSENT_AMALGAMATION_OUT),
       datacy: 'consent-to-amalgamate-out',
       label: t('label.filing.staffFilingOptions.consentToAmalgamateOut'),
       click: () => {
@@ -123,8 +123,8 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       }
     },
     { // <!-- Amalgamate -->
-      showButton: currentBusiness.value?.state !== BusinessStateE.HISTORICAL && showAmalgamateOut.value,
-      disabled: !business.isAllowedToFile(FilingTypes.AMALGAMATION_OUT),
+      showButton: !isHistorical.value && showAmalgamateOut.value,
+      disabled: !business.isAllowed(AllowableActionE.AMALGAMATION_OUT),
       datacy: 'amalgamate-out',
       label: t('label.filing.staffFilingOptions.amalgamateOut'),
       click: () => {
@@ -132,8 +132,8 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       }
     },
     { // <!-- Consent to Continue Out -->
-      showButton: currentBusiness.value?.state !== BusinessStateE.HISTORICAL && showConsentContinueOut.value,
-      disabled: !business.isAllowedToFile(FilingTypes.CONSENT_CONTINUATION_OUT),
+      showButton: !isHistorical.value && showConsentContinueOut.value,
+      disabled: !business.isAllowed(AllowableActionE.CONSENT_CONTINUATION_OUT),
       datacy: 'consent-to-continue-out',
       label: t('label.filing.staffFilingOptions.consentToContinueOut'),
       click: () => {
@@ -141,7 +141,7 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       }
     },
     { // <!-- Continue Out -->
-      showButton: currentBusiness.value?.state !== BusinessStateE.HISTORICAL && showContinueOut.value,
+      showButton: !isHistorical.value && showContinueOut.value,
       disabled: !business.isAllowedToFile(FilingTypes.CONTINUATION_OUT),
       datacy: 'continue-out',
       label: t('label.filing.staffFilingOptions.continueOut'),
@@ -150,14 +150,14 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       }
     },
     { // <!-- Extend Limited Restoration  -->
-      showButton: business.isAllowedToFile(FilingTypes.RESTORATION, FilingSubTypeE.LIMITED_RESTORATION_EXTENSION),
+      showButton: business.isAllowed(AllowableActionE.LIMITED_RESTORATION_EXTENSION),
       disabled: false,
       datacy: 'extend-limited-restore',
       label: t('label.filing.staffFilingOptions.extendLimitedRestoration'),
       click: () => { restoreCompany(FilingSubTypeE.LIMITED_RESTORATION_EXTENSION) }
     },
     { // <!-- Convert to Full Restoration  -->
-      showButton: business.isAllowedToFile(FilingTypes.RESTORATION, FilingSubTypeE.LIMITED_RESTORATION_TO_FULL),
+      showButton: business.isAllowed(AllowableActionE.LIMITED_RESTORATION_TO_FULL),
       disabled: false,
       datacy: 'convert-full-restore',
       label: t('label.filing.staffFilingOptions.fullRestoration'),

--- a/src/stores/business.ts
+++ b/src/stores/business.ts
@@ -32,6 +32,9 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
 
     return currentBusiness.value.legalName
   })
+
+  const isHistorical = computed((): boolean => currentBusiness.value?.state === BusinessStateE.HISTORICAL)
+
   const currentBusinessContact = ref({} as ContactBusinessI)
   // errors
   const errors: Ref<ErrorI[]> = ref([])
@@ -276,15 +279,11 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
 
   /** Check if the specified action is allowed, else False */
   const isAllowed = (action: AllowableActionE): boolean => {
-    // const isBusiness = !!sessionStorage.getItem('BUSINESS_ID') // ie, not a temporary business
-
-    // TO-DO: the above line is commented out because we do not have 'BUSINESS_ID' in the sessionStorage
-    // For now, we check if the currentBusiness exists in the business store.
-    const isBusiness = !!currentBusiness.value.identifier
+    const isBusiness = !!currentBusiness.value?.identifier
 
     const { isStaffAccount } = useBcrosAccount()
     const { getFeatureFlag } = useBcrosLaunchdarkly()
-    const legalType = currentBusiness.value.legalType
+    const legalType = currentBusiness.value?.legalType
 
     switch (action) {
       case AllowableActionE.ADDRESS_CHANGE: {
@@ -542,6 +541,7 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
     currentBusinessAddresses,
     currentParties,
     businessConfig,
+    isHistorical,
     getBusinessAddress,
     getBusinessContact,
     getBusinessDetails,


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/23820

*Description of changes:*
Update the display logic for the menu options in the "Add Staff Filing" dropdown, using the same logic as the old codebase (https://github.com/bcgov/business-filings-ui/blob/3a62b2b470bf16c181b879057823ff795e5faf68/src/components/Dashboard/StaffNotation.vue#L85-L230)

Major update: instead of calling the `isAllowedToFile(FilingTypes)`, use the wrapper function `isAllowed(AllowableActionE)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
