### PR TITLE
Bug fix - voluntary dissolution text in tombstone

### DIFF
--- a/src/components/bcros/businessDetails/Status.vue
+++ b/src/components/bcros/businessDetails/Status.vue
@@ -40,10 +40,10 @@ const getReasonText = computed(() => {
         reason = t('filing.reason.dissolutionAdministrative')
         break
       case FilingSubTypeE.DISSOLUTION_INVOLUNTARY:
-        reason = t('filing.reason.dissolutionAdministrative')
+        reason = t('filing.reason.involuntaryDissolution')
         break
       case FilingSubTypeE.DISSOLUTION_VOLUNTARY:
-        reason = isFirm ? t('filing.reason.dissolutionFirm') : t('filing.reason.dissolutionAdministrative')
+        reason = isFirm ? t('filing.reason.dissolutionFirm') : t('filing.reason.voluntaryDissolution')
     }
 
     const dissolutionDate = yyyyMmDdToDate(stateFiling.value?.dissolution?.dissolutionDate)

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -535,6 +535,7 @@
       "dissolutionAdministrative": "Administrative Dissolution",
       "involuntaryDissolution": "Dissolved for Failure to File",
       "dissolutionFirm": "Dissolution",
+      "voluntaryDissolution": "Voluntary Dissolution",
       "continuationOut": "Continuation Out"
     }
   },


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24011

*Description of changes:*
Update the i18n so the dissolution type can be displayed correctly in the tombstone of a historical business. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
