### PR TITLE
Fix change buttons in side accordions

### DIFF
--- a/cypress/e2e/components/addresses.cy.ts
+++ b/cypress/e2e/components/addresses.cy.ts
@@ -59,4 +59,14 @@ context('Business dashboard -> Address side component', () => {
   //   cy.get('[data-cy="address-change-button"]').click()
   //   cy.get('[data-cy="continue-to-coa-button"]').should('not.exist')
   // })
+
+  it('Change button does not exist for historical businesses', () => {
+    cy.visitBusinessDashFor('businessInfo/bc/historical.json')
+    cy.get('[data-cy="address-change-button"]').should('not.exist')
+  })
+
+  it('Change button is disabled when \'changeOfAddress\' is not in allowable actions', () => {
+    cy.visitBusinessDashFor('businessInfo/ben/unable-to-change-address-and-party.json')
+    cy.get('[data-cy="address-change-button"]').should('be.disabled')
+  })
 })

--- a/cypress/e2e/components/directors-partners-proprietors.cy.ts
+++ b/cypress/e2e/components/directors-partners-proprietors.cy.ts
@@ -1,19 +1,55 @@
 context('Business dashboard -> Side components: Current Directors, Partners, Proprietors', () => {
   it('Directors accordion is rendered', () => {
-    cy.visitBusinessDash('BC0871427', 'BEN')
-    cy.get('[data-cy="accordion_directors"]').should('exist')
-    cy.get('[data-cy="accordion_directors"]').children().eq(0).children().should('have.length', 5)
+    cy.visitBusinessDashFor('businessInfo/ben/active.json')
+    cy.get('[data-cy="accordion_directors"]')
+      .should('exist')
+      .children().eq(0).children()
+      .should('have.length', 5)
+      .get('[data-cy="header_directors"]')
+      .should('contain', 'Current Directors')
+
+    cy.intercept('GET', '**/BC**/standalone-directors**').as('changeDirector')
+    cy.get('[data-cy="change-button"]')
+      .should('exist')
+      .click()
+      .wait('@changeDirector')
   })
 
   it('Partners accordion is rendered', () => {
-    cy.visitBusinessDash('FM1060265', 'GP')
-    cy.get('[data-cy="accordion_partners"]').should('exist')
-    cy.get('[data-cy="accordion_partners"]').children().eq(0).children().should('have.length', 3)
+    cy.visitBusinessDashFor('businessInfo/gp/active.json')
+    cy.get('[data-cy="accordion_partners"]')
+      .should('exist')
+      .children().eq(0).children()
+      .should('have.length', 3)
+      .get('[data-cy="header_partner"]')
+      .should('contain', 'Partners')
+
+    cy.intercept('GET', '**/FM**/change**').as('changePartner')
+    cy.get('[data-cy="change-button"]').should('exist').click()
+    cy.wait('@changePartner')
   })
 
   it('Proprietors accordion is rendered', () => {
-    cy.visitBusinessDash('FM1060270', 'SP')
-    cy.get('[data-cy="accordion_proprietors"]').should('exist')
-    cy.get('[data-cy="accordion_proprietors"]').children().eq(0).children().should('have.length', 1)
+    cy.visitBusinessDashFor('businessInfo/sp/active.json')
+    cy.get('[data-cy="accordion_proprietors"]')
+      .should('exist')
+      .children().eq(0).children()
+      .should('have.length', 1)
+      .get('[data-cy="header_proprietors"]')
+      .should('contain', 'Proprietors')
+
+    cy.intercept('GET', '**/FM**/change**').as('changeProprietor')
+    cy.get('[data-cy="change-button"]').should('exist').click()
+    cy.wait('@changeProprietor')
+  })
+
+  it('Change button does not exist for historical businesses', () => {
+    cy.visitBusinessDashFor('businessInfo/bc/historical.json')
+    cy.get('[data-cy="change-button"]').should('not.exist')
+  })
+
+  it('Change button is disabled when \'changeOfDirector\' is not in allowable actions', () => {
+    cy.visitBusinessDashFor('businessInfo/ben/unable-to-change-address-and-party.json')
+    cy.get('[data-cy="change-button"]').should('be.disabled')
   })
 })

--- a/cypress/fixtures/businessInfo/ben/unable-to-change-address-and-party.json
+++ b/cypress/fixtures/businessInfo/ben/unable-to-change-address-and-party.json
@@ -1,0 +1,127 @@
+{
+  "business": {
+    "adminFreeze": false,
+    "allowedActions": {
+      "digitalBusinessCard": false,
+      "filing": {
+        "filingSubmissionLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/BC0871427/filings",
+        "filingTypes": [
+          {
+            "displayName": "Admin Freeze",
+            "feeCode": "NOFEE",
+            "name": "adminFreeze"
+          },
+          {
+            "displayName": "Request for AGM Extension",
+            "feeCode": "AGMDT",
+            "name": "agmExtension"
+          },
+          {
+            "displayName": "AGM Location Change",
+            "feeCode": "AGMLC",
+            "name": "agmLocationChange"
+          },
+          {
+            "displayName": "Alteration",
+            "feeCode": "ALTER",
+            "name": "alteration"
+          },
+          {
+            "displayName": "Amalgamation Application (Regular)",
+            "feeCode": "AMALR",
+            "name": "amalgamationApplication",
+            "type": "regular"
+          },
+          {
+            "displayName": "Amalgamation Application Short-form (Vertical)",
+            "feeCode": "AMALV",
+            "name": "amalgamationApplication",
+            "type": "vertical"
+          },
+          {
+            "displayName": "Amalgamation Application Short-form (Horizontal)",
+            "feeCode": "AMALH",
+            "name": "amalgamationApplication",
+            "type": "horizontal"
+          },
+          {
+            "displayName": "Annual Report",
+            "feeCode": "BCANN",
+            "name": "annualReport"
+          },
+          {
+            "displayName": "6-Month Consent to Continue Out",
+            "feeCode": "CONTO",
+            "name": "consentContinuationOut"
+          },
+          {
+            "displayName": "Register Correction Application",
+            "feeCode": "CRCTN",
+            "name": "correction"
+          },
+          {
+            "displayName": "Court Order",
+            "feeCode": "NOFEE",
+            "name": "courtOrder"
+          },
+          {
+            "displayName": "Voluntary Dissolution",
+            "feeCode": "DIS_VOL",
+            "name": "dissolution",
+            "type": "voluntary"
+          },
+          {
+            "displayName": "Administrative Dissolution",
+            "feeCode": "DIS_ADM",
+            "name": "dissolution",
+            "type": "administrative"
+          },
+          {
+            "displayName": "Registrar's Notation",
+            "feeCode": "NOFEE",
+            "name": "registrarsNotation"
+          },
+          {
+            "displayName": "Registrar's Order",
+            "feeCode": "NOFEE",
+            "name": "registrarsOrder"
+          },
+          {
+            "displayName": "Transition Application",
+            "feeCode": "TRANS",
+            "name": "transition"
+          }
+        ]
+      }
+    },
+    "alternateNames": [],
+    "arMaxDate": "2024-06-28",
+    "arMinDate": "2024-06-27",
+    "associationType": null,
+    "complianceWarnings": [],
+    "fiscalYearEndDate": "2023-06-27",
+    "foundingDate": "2023-06-27T21:48:45.599278+00:00",
+    "goodStanding": true,
+    "hasCorrections": false,
+    "hasCourtOrders": false,
+    "hasRestrictions": false,
+    "identifier": "BC0871427",
+    "inDissolution": false,
+    "lastAddressChangeDate": "2023-06-27",
+    "lastAnnualGeneralMeetingDate": "",
+    "lastAnnualReportDate": "",
+    "lastDirectorChangeDate": "2024-05-22",
+    "lastLedgerTimestamp": "2023-06-27T21:48:47.354364+00:00",
+    "lastModified": "2024-05-22T16:22:39.006738+00:00",
+    "legalName": "0871427 B.C. LTD.",
+    "legalType": "BEN",
+    "naicsCode": null,
+    "naicsDescription": null,
+    "naicsKey": null,
+    "nextAnnualReport": "2024-06-27T07:00:00+00:00",
+    "noDissolution": false,
+    "state": "ACTIVE",
+    "submitter": "bcsc/jocxgslo54oopxozrht4uuneaxzhubek",
+    "warnings": []
+  }
+}

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -323,13 +323,31 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
     <div v-if="!!bootstrapIdentifier" class="bcros-dash-col bcros-dash-side-col">
       <BcrosSection name="temp-reg-offices">
         <template #header>
-          {{ bootstrapOfficeTitle }}
+          <div class="flex justify-between">
+            <span>{{ bootstrapOfficeTitle }}</span>
+            <UButton
+              variant="ghost"
+              icon="i-mdi-pencil"
+              :disabled="true"
+              :label="$t('button.general.change')"
+              data-cy="address-change-button"
+            />
+          </div>
         </template>
         <BcrosOfficeAddressBootstrap :items="bootstrapOffices" />
       </BcrosSection>
       <BcrosSection name="temp-reg-parties">
         <template #header>
-          {{ bootstrapPartiesTitle }}
+          <div class="flex justify-between">
+            <span>{{ bootstrapPartiesTitle }}</span>
+            <UButton
+              variant="ghost"
+              icon="i-mdi-pencil"
+              :disabled="true"
+              :label="$t('button.general.change')"
+              data-cy="change-button"
+            />
+          </div>
         </template>
         <div class="flex justify-center py-5">
           <p>{{ $t('text.filing.completeYourFiling') }}</p>

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -5,7 +5,10 @@ const route = useRoute()
 const t = useNuxtApp().$i18n.t
 
 const business = useBcrosBusiness()
-const { currentParties, currentBusinessAddresses, currentBusiness } = storeToRefs(business)
+const { currentParties, currentBusinessAddresses, currentBusiness, isHistorical } = storeToRefs(business)
+
+const { goToEditPage } = useBcrosNavigate()
+
 const { isStaffAccount } = useBcrosAccount()
 
 const bootstrap = useBcrosBusinessBootstrap()
@@ -186,24 +189,6 @@ const pendingAddress = computed(() => {
   return false
 })
 
-const hasProgressCorrections = computed(() => {
-  if (filings && filings.value && filings.value.length > 0) {
-    const corrections = filings.value.filter((filing) => {
-      return filing.name === FilingTypes.CORRECTION &&
-        (filing.status === FilingStatusE.DRAFT ||
-        filing.status === FilingStatusE.PENDING ||
-        filing.status === FilingStatusE.PENDING_CORRECTION)
-    })
-    return corrections.length > 0
-  }
-  return false
-})
-
-const isChangeAddressDisabled = computed(() =>
-  business.currentBusiness.adminFreeze || pendingAddress.value || hasProgressCorrections.value
-)
-
-const isChangeDirectorDisabled = computed(() => business.currentBusiness.adminFreeze || hasProgressCorrections.value)
 const showChangeOfAddress = ref(false)
 
 const setChangeOfAddress = (show: boolean) => {
@@ -234,11 +219,9 @@ const goToStandaloneDirectors = () => {
   navigateTo(url, { external: true })
 }
 
-const changeDirectors = () => {
+const changePartyInfo = () => {
   if (business.isEntityFirm()) {
-    const baseUrl = useRuntimeConfig().public.editApiURL
-    const url = `${baseUrl}/${business.currentBusinessIdentifier}/change`
-    navigateTo(url, { external: true })
+    goToEditPage(`/${currentBusiness.value.identifier}/change`)
   } else {
     goToStandaloneDirectors()
   }
@@ -292,6 +275,7 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
       </div>
     </template>
   </BcrosDialogCardedModal>
+
   <div class="mt-8 mb-16 flex flex-wrap" data-cy="business-dashboard">
     <div class="md:w-9/12 bcros-dash-col">
       <BcrosSection v-if="alerts && alerts.length>0" name="alerts">
@@ -335,6 +319,7 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
       </BcrosSection>
     </div>
 
+    <!-- Side Components for Bootstrap Addresses -->
     <div v-if="!!bootstrapIdentifier" class="bcros-dash-col bcros-dash-side-col">
       <BcrosSection name="temp-reg-offices">
         <template #header>
@@ -351,7 +336,9 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
         </div>
       </BcrosSection>
     </div>
+
     <div v-else-if="!!currentBusiness" class="bcros-dash-col bcros-dash-side-col">
+      <!-- Custodian of Records -->
       <BcrosSection v-if="showCustodian" name="custodian">
         <template #header>
           <div class="flex justify-between">
@@ -363,6 +350,7 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
         <BcrosPartyInfo name="custodian" :role-type="RoleTypeE.CUSTODIAN" :show-email="false" :expand-top-item="true" />
       </BcrosSection>
 
+      <!-- Office Addresses -->
       <BcrosSection name="address">
         <template #header>
           <div class="flex justify-between">
@@ -372,6 +360,7 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
             <span v-else>
               {{ $t('title.section.officeAddresses') }}
             </span>
+            <!-- TO-DO: tooltip is needed for this pending badge -->
             <UBadge
               v-if="pendingAddress"
               data-cy="address-pending-badge"
@@ -381,9 +370,10 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
               {{ $t('label.general.pending') }}
             </UBadge>
             <UButton
+              v-if="!business.isDisableNonBenCorps() && !isHistorical"
               variant="ghost"
               icon="i-mdi-pencil"
-              :disabled="isChangeAddressDisabled"
+              :disabled="!business.isAllowed(AllowableActionE.ADDRESS_CHANGE)"
               :label="$t('button.general.change')"
               data-cy="address-change-button"
               @click="changeAddress"
@@ -397,6 +387,7 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
         />
       </BcrosSection>
 
+      <!-- Current Director -->
       <BcrosSection v-if="hasDirector" name="directors">
         <template #header>
           <div class="flex justify-between">
@@ -404,18 +395,20 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
               {{ $t('title.section.currentDirectors') }}
             </span>
             <UButton
+              v-if="!business.isDisableNonBenCorps() && !isHistorical"
               variant="ghost"
               icon="i-mdi-pencil"
-              :disabled="isChangeDirectorDisabled"
+              :disabled="!business.isAllowed(AllowableActionE.DIRECTOR_CHANGE)"
               :label="$t('button.general.change')"
               data-cy="change-button"
-              @click="changeDirectors"
+              @click="changePartyInfo"
             />
           </div>
         </template>
         <BcrosPartyInfo name="directors" :role-type="RoleTypeE.DIRECTOR" :show-email="false" />
       </BcrosSection>
 
+      <!-- Partners -->
       <BcrosSection v-if="hasPartner" name="partner">
         <template #header>
           <div class="flex justify-between">
@@ -423,20 +416,20 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
               {{ $t('title.section.partners') }}
             </span>
             <UButton
+              v-if="!isHistorical"
               variant="ghost"
               icon="i-mdi-pencil"
+              :disabled="!business.isAllowed(AllowableActionE.DIRECTOR_CHANGE)"
               :label="$t('button.general.change')"
               data-cy="change-button"
-              @click="()=>{
-                // TO-DO  confirm the redirect logic
-                console.log('clicked!')
-              }"
+              @click="changePartyInfo"
             />
           </div>
         </template>
         <BcrosPartyInfo name="partners" :role-type="RoleTypeE.PARTNER" :show-email="true" />
       </BcrosSection>
 
+      <!-- Proprietor -->
       <BcrosSection v-if="hasProprietor" name="proprietors">
         <template #header>
           <div class="flex justify-between">
@@ -444,14 +437,13 @@ const coaDialogOptions = computed<DialogOptionsI>(() => {
               {{ $t('title.section.proprietors') }}
             </span>
             <UButton
+              v-if="!isHistorical"
               variant="ghost"
               icon="i-mdi-pencil"
+              :disabled="!business.isAllowed(AllowableActionE.DIRECTOR_CHANGE)"
               :label="$t('button.general.change')"
               data-cy="change-button"
-              @click="()=>{
-                // TO-DO  confirm the redirect logic
-                console.log('clicked!')
-              }"
+              @click="changePartyInfo"
             />
           </div>
         </template>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24010

*Description of changes:*
1. Fix logic for change buttons in all side accordions (Office Addresses, Current Directors, Partners, Proprietors). 
    check the `v-if` and `:disabled=` in all the `<v-btn>` tags this code snippet https://github.com/bcgov/business-filings-ui/blob/3a62b2b470bf16c181b879057823ff795e5faf68/src/views/Dashboard.vue#L84-L221
   
2. Bootstrap businesses always have disabled 'Change' buttons in the side accordions
3. Add cypress tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
