### PR TITLE
enable 'cancel' button in the comment modal

### DIFF
--- a/cypress/e2e/components/comments.cy.ts
+++ b/cypress/e2e/components/comments.cy.ts
@@ -30,6 +30,28 @@ context('Business dashboard -> Comment side modal', () => {
     cy.get('[data-cy="comment-list"]').should('exist')
   })
 
+  it('the comment modal can be closed', () => {
+    cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, undefined, allFilings, true)
+
+    // open the comment
+    cy.get('[data-cy="header.actions.dropdown"] button').eq(0).click()
+    cy.get('.i-mdi-comment-plus').click()
+    cy.get('[data-cy="comment"]').should('exist')
+
+    // click the cancel button to close the modal
+    cy.get('[data-cy="cancel-comment"]').click()
+    cy.get('[data-cy="comment"]').should('not.exist')
+
+    // open the comment again
+    cy.get('[data-cy="header.actions.dropdown"] button').eq(0).click()
+    cy.get('.i-mdi-comment-plus').click()
+    cy.get('[data-cy="comment"]').should('exist')
+
+    // click the X icon to close the modal
+    cy.get('.i-mdi-close').click()
+    cy.get('[data-cy="comment"]').should('not.exist')
+  })
+
   it('Should add a comment', () => {
     const commentText = 'Test comment'
     cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, undefined, allFilings, true)

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -240,8 +240,9 @@ const contacts = getContactInfo('registries')
         </div>
       </template>
     </BcrosDialog>
+
     <!-- Staff Comments -->
-    <span v-if="hasRoleStaff" class="h-[26px]">
+    <div v-if="hasRoleStaff">
       <UModal v-model="isCommentOpen" :ui="{base: 'absolute left-10 top-5 bottom-5'}">
         <BcrosComment :comments="comments" :business="currentBusiness.identifier" @close="showCommentDialog(false)" />
       </UModal>
@@ -259,9 +260,10 @@ const contacts = getContactInfo('registries')
         </template>
         <span class="font-13 ml-1 text-nowrap">{{ $t('label.comments.comment', (comments?.length || 0 )) }}</span>
       </UButton>
-    </span>
+    </div>
+
     <!-- COLIN link button -->
-    <span
+    <div
       v-if="!!currentBusinessIdentifier && isDisableNonBenCorps()"
     >
       <BcrosTooltip
@@ -281,10 +283,10 @@ const contacts = getContactInfo('registries')
           <span class="font-13 ml-1">{{ $t('button.tombstone.colinLink') }}</span>
         </UButton>
       </BcrosTooltip>
-    </span>
+    </div>
 
     <!-- View and Change Business Information -->
-    <span
+    <div
       v-if="!isDisableNonBenCorps() &&
         !!currentBusinessIdentifier &&
         currentBusiness.state !== BusinessStateE.HISTORICAL"
@@ -317,10 +319,10 @@ const contacts = getContactInfo('registries')
           name="i-mdi-alert"
         />
       </BcrosTooltip>
-    </span>
+    </div>
 
     <!-- Download Business Summary -->
-    <span v-if="!isDisableNonBenCorps() && isAllowedBusinessSummary">
+    <div v-if="!isDisableNonBenCorps() && isAllowedBusinessSummary">
       <BcrosTooltip
         :text="$t('tooltip.filing.button.businessSummary')"
         :popper="{
@@ -347,7 +349,7 @@ const contacts = getContactInfo('registries')
           <span class="font-13 ml-1 text-nowrap">{{ $t('button.tombstone.businessSummary') }}</span>
         </UButton>
       </BcrosTooltip>
-    </span>
+    </div>
 
     <div class="mb-2 mt-2">
       <BcrosBusinessDetailsLinkActions

--- a/src/components/bcros/comment/Index.vue
+++ b/src/components/bcros/comment/Index.vue
@@ -82,7 +82,7 @@ const saveComment = async () => {
 
 <template>
   <!-- comment-text-->
-  <div class="px-5 py-5">
+  <div class="px-5 py-5" data-cy="comment">
     <slot name="comment-header">
       <span class="text-primary-600">
         <UIcon name="i-mdi-comment-text" class="w-5 h-5" />
@@ -116,9 +116,8 @@ const saveComment = async () => {
           <UButton
             class="text-primary-600 px-3 py-2 mb-2"
             variant="ghost"
-            :disabled="!commentToAdd || commentToAdd.length === 0"
-            data-cy="cancel-save-comment"
-            @click="commentToAdd = ''"
+            data-cy="cancel-comment"
+            @click="$emit('close')"
           >
             <span>{{ $t('label.comments.cancel') }}</span>
           </UButton>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24292

*Description of changes:*
Fix the bug so the cancel button in the staff comment modal is working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
