### PR TITLE
24495 - staff comment and staff filing option should not be displayed for bootstrap business

### DIFF
--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -242,7 +242,7 @@ const contacts = getContactInfo('registries')
     </BcrosDialog>
 
     <!-- Staff Comments -->
-    <div v-if="hasRoleStaff">
+    <div v-if="hasRoleStaff && currentBusiness">
       <UModal v-model="isCommentOpen" :ui="{base: 'absolute left-10 top-5 bottom-5'}">
         <BcrosComment :comments="comments" :business="currentBusiness.identifier" @close="showCommentDialog(false)" />
       </UModal>

--- a/src/components/bcros/filing/addStaffFiling/Index.vue
+++ b/src/components/bcros/filing/addStaffFiling/Index.vue
@@ -204,7 +204,7 @@ const actions: ComputedRef<Array<Array<MenuActionItem>>> = computed(() => {
       @close="openPutBackOnModal = false"
     />
 
-    <UDropdown v-if="actions[0].length > 0" :items="actions" :popper="{ placement: 'bottom-start' }">
+    <UDropdown v-if="actions[0].length > 0 && currentBusiness" :items="actions" :popper="{ placement: 'bottom-start' }">
       <template #default>
         <UButton variant="ghost" data-cy="add-staff-filing" label="Add Staff Filing" icon="i-mdi-plus" />
       </template>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24495

*Description of changes:*
In business dashboard for a bootstrap business, the staff comment (in tombstone) and the 'Add Staff Filing' dropdown (in the header of the filing history section) should not be display. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
