### PR TITLE
'Consent to Continue Out' - fix filing history text and display badge in tombstone

### DIFF
--- a/src/components/bcros/businessDetails/Status.vue
+++ b/src/components/bcros/businessDetails/Status.vue
@@ -6,9 +6,10 @@ const {
   currentBusiness,
   currentBusinessIdentifier,
   stateFiling,
-  isInLimitedRestoration,
-  isAuthorizedToContinueOut
+  isInLimitedRestoration
 } = storeToRefs(useBcrosBusiness())
+
+const { isAuthorizedToContinueOut } = storeToRefs(useBcrosFilings())
 
 const getReasonText = computed(() => {
   if (currentBusiness.value.state !== BusinessStateE.HISTORICAL) {

--- a/src/components/bcros/filing/item/ConsentContinuationOut.vue
+++ b/src/components/bcros/filing/item/ConsentContinuationOut.vue
@@ -3,8 +3,8 @@
     <template #body>
       <div>
         <p v-if="expiry && !isConsentExpired" class="mt-0">
-          {{ $t('text.filing.continuation.consentContinueOutTo') }} {{ foreignJurisdiction }}&nbsp;
-          {{ $t('text.filing.continuation.isValid') }}&nbsp;
+          {{ $t('text.filing.continuation.consentContinueOutTo') }} {{ foreignJurisdiction }}
+          {{ $t('text.filing.continuation.isValid') }}
           <strong>{{ $t('text.filing.continuation.until') }}&nbsp;{{ expiry }}</strong>.
         </p>
 
@@ -34,7 +34,7 @@ const expiry = props.filing.data?.consentContinuationOut?.expiry
   : null
 
 /** Check if Consent is Expired. (Assumes expiry is not empty.) */
-const isConsentExpired = (): boolean => {
+const isConsentExpired: Ref<boolean> = computed(() => {
   const expiry = props.filing.data?.consentContinuationOut?.expiry
   if (expiry) {
     const date = new Date(expiry)
@@ -44,16 +44,16 @@ const isConsentExpired = (): boolean => {
     }
   }
   return false
-}
+})
 
 const getRegionName = (countryShortCode: string, regionShortCode: string): string =>
   regionShortCode.toUpperCase() === 'FEDERAL'
     ? 'Federal'
-    : iso3166.subdivision(countryShortCode, regionShortCode)
+    : iso3166.subdivision(countryShortCode, regionShortCode).name
 
-const foreignJurisdiction = (): string => {
+const foreignJurisdiction: Ref<string> = computed(() => {
   const foreignJurisdictionCountry = props.filing.data?.consentContinuationOut?.country?.toUpperCase()
-  const countryName = iso3166.country(foreignJurisdictionCountry)
+  const countryName = iso3166.country(foreignJurisdictionCountry).name
   const regionShortCode = props.filing.data?.consentContinuationOut?.region?.toUpperCase()
   const regionName = getRegionName(foreignJurisdictionCountry, regionShortCode)
 
@@ -62,5 +62,5 @@ const foreignJurisdiction = (): string => {
   } else {
     return countryName
   }
-}
+})
 </script>

--- a/src/stores/business.ts
+++ b/src/stores/business.ts
@@ -238,15 +238,6 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
     return isTypeRestorationLimited.value || isTypeRestorationLimitedExtension.value
   })
 
-  const isAuthorizedToContinueOut = computed(() => {
-    const expiryDate = stateFiling.value?.consentContinuationOut?.expiry
-    if (expiryDate) {
-      const ccoExpiryDate = new Date(expiryDate)
-      return ccoExpiryDate >= new Date()
-    }
-    return false
-  })
-
   // computed variables for staff filing options
   const showConsentAmalgamationOut = computed(() => {
     return (
@@ -569,7 +560,6 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
     isTypeRestorationLimited,
     isTypeRestorationFull,
     isFirm,
-    isAuthorizedToContinueOut,
     showAmalgamateOut,
     showConsentAmalgamationOut,
     showContinueOut,

--- a/src/stores/filings.ts
+++ b/src/stores/filings.ts
@@ -14,6 +14,24 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
   const apiURL = useRuntimeConfig().public.legalApiURL
 
   const downloadingInProgress = ref(false)
+
+  /** Whether the business is authorized to continue out, i.e. true if cco expiry date is present or in the future. */
+  const isAuthorizedToContinueOut = computed(() => {
+    const ccoFiling = filings.value?.find((val) => {
+      const exp = val.data?.consentContinuationOut?.expiry
+      if (exp) {
+        return true
+      }
+      return false
+    })
+    if (ccoFiling) {
+      const exp = ccoFiling.data?.consentContinuationOut?.expiry
+      const ccoExpiryDate = apiToDate(exp)
+      return ccoExpiryDate >= new Date()
+    }
+    return false
+  })
+
   const setDownloadingInProgress = (isDownloading: boolean) => {
     downloadingInProgress.value = isDownloading
   }
@@ -137,6 +155,7 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
     loading,
     errors,
     downloadingInProgress,
+    isAuthorizedToContinueOut,
     loadFilings,
     loadBootstrapFiling,
     clearFilings,


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24375

*Description of changes:*
- Fix the text display for Consent to Continue Out filing
- Display "AUTHORIZED TO CONTINUE OUT" in the tombstone

Example business: BC0883688
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a7242793-792d-44d4-8f47-42d3e399c45f">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
