### PR TITLE
Fix for non staff user view/change business info modal

### DIFF
--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -63,7 +63,7 @@ const setShowDissolutionDialog = (show: boolean) => {
 }
 
 const dialogTitle = computed<string>(() => {
-  return (!currentBusiness?.value?.goodStanding && hasRoleStaff)
+  return showChangeNotInGoodStandingDialog.value
     ? t('title.dialog.notGoodStanding.notInGoodStanding')
     : businessConfig.value?.dissolutionConfirmation.modalTitle
 })
@@ -187,7 +187,7 @@ const contacts = getContactInfo('registries')
       @close="closeNotGoodStandingDialog"
     >
       <template #content>
-        <div v-if="(!currentBusiness.goodStanding && hasRoleStaff)">
+        <div v-if="showChangeNotInGoodStandingDialog">
           <p>
             {{ showDissolutionText
               ? $t('text.dialog.notGoodStanding.notGoodStanding1')
@@ -213,7 +213,7 @@ const contacts = getContactInfo('registries')
         </div>
       </template>
       <template #buttons>
-        <div v-if="(!currentBusiness.goodStanding && hasRoleStaff)" class="flex justify-center gap-5">
+        <div v-if="showChangeNotInGoodStandingDialog" class="flex justify-center gap-5">
           <UButton
             variant="outline"
             class="px-10 py-2"


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24459

*Description of changes:*
Fix the text that shows for non staff user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
