### PR TITLE
24464 - fix: iron out discrepancies in use of FF between current and new (this) dashboard.

### DIFF
--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -243,7 +243,7 @@ const contacts = getContactInfo('registries')
     </BcrosDialog>
 
     <!-- Staff Comments -->
-    <div v-if="hasRoleStaff && currentBusiness">
+    <div v-if="hasRoleStaff && currentBusiness && !isDisableNonBenCorps()">
       <UModal v-model="isCommentOpen" :ui="{base: 'absolute left-10 top-5 bottom-5'}">
         <BcrosComment :comments="comments" :business="currentBusiness.identifier" @close="showCommentDialog(false)" />
       </UModal>

--- a/src/components/bcros/filing/addStaffFiling/Index.vue
+++ b/src/components/bcros/filing/addStaffFiling/Index.vue
@@ -10,6 +10,7 @@ interface MenuActionItem extends DropdownItem {
 
 const filings = useBcrosFilings()
 const business = useBcrosBusiness()
+const { getStoredFlag } = useBcrosLaunchdarkly()
 const { isActionVisible } = useBcrosDashboardActions()
 const { currentBusiness } = storeToRefs(business)
 const { goToBusinessDashboard, goToEditPage, goToCreatePage } = useBcrosNavigate()
@@ -131,7 +132,9 @@ const allActions: ComputedRef<Array<MenuActionItem>> = computed(() => {
       }
     },
     { // <!-- Consent to Continue Out -->
-      showButton: isActionVisible(AllowableActionE.CONSENT_CONTINUATION_OUT),
+      showButton: !!getStoredFlag('supported-consent-continuation-out-entities')?.includes(
+          currentBusiness.value.legalType) &&
+        isActionVisible(AllowableActionE.CONSENT_CONTINUATION_OUT),
       disabled: !business.isAllowed(AllowableActionE.CONSENT_CONTINUATION_OUT),
       datacy: 'consent-to-continue-out',
       label: t('label.filing.staffFilingOptions.consentToContinueOut'),

--- a/src/stores/business.ts
+++ b/src/stores/business.ts
@@ -448,19 +448,14 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
   }
 
   /**
-   * Is True for non-BEN corps if FF is disabled.
-   * Is False for BENs and other entity types.
+   * Is True for any business in the FF list, else False.
    * Used to apply special pre-go-live functionality.
    */
   function isDisableNonBenCorps (): boolean {
-    if (
-      isLegalType([CorpTypeCd.BC_COMPANY, CorpTypeCd.BC_CCC, CorpTypeCd.BC_ULC_COMPANY, CorpTypeCd.CONTINUE_IN,
-        CorpTypeCd.CCC_CONTINUE_IN, CorpTypeCd.ULC_CONTINUE_IN
-      ])
-    ) {
-      return !launchdarklyStore.getFeatureFlag('enable-non-ben-corps')
-    }
-    return false
+    // initially, this was True for all non-BEN corps (when FF was off)
+    // now, this is True for the specified businesses only
+    return currentBusiness?.value?.identifier && !!launchdarklyStore
+      .getFeatureFlag('businesses-to-manage-in-colin')?.includes(currentBusiness.value.identifier)
   }
 
   /**


### PR DESCRIPTION
*Issue:24464 *https://github.com/bcgov/entity/issues/24464 

*Description of changes:*
- implement new FF 'businesses-to-manage-in-colin'
- verify other flags are used, and in proper places:
  - supported-agm-extension-entities
  - supported-agm-location-chg-entities
  - supported-amalgamation-entities
  - supported-business-summary-entities
  - supported-consent-continuation-out-entities
  - supported-correction-entities
  - supported-put-back-on-entities
  - supported-restoration-entities

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
