### PR TITLE
fix for missing information on incorp requests

### DIFF
--- a/src/stores/businessBootstrap.ts
+++ b/src/stores/businessBootstrap.ts
@@ -12,7 +12,10 @@ export const useBcrosBusinessBootstrap = defineStore('bcros/businessBootstrap', 
   const isStoreLoading = ref(false)
   const pendingFilings: Ref<PendingItemI[]> = ref([])
   const bootstrapIdentifier = computed(() => bootstrapFiling.value?.filing.business.identifier)
-  const bootstrapLegalType = computed(() => bootstrapFiling.value?.filing.business.legalType || bootstrapFiling.value?.filing?.incorporationApplication?.nameRequest?.legalType)
+  const bootstrapLegalType = computed(() => {
+    return bootstrapFiling.value?.filing.business.legalType ||
+      bootstrapFiling.value?.filing?.incorporationApplication?.nameRequest?.legalType
+  })
   const bootstrapFilingType = computed(() => bootstrapFiling.value?.filing.header.name)
   const bootstrapFilingStatus = computed(() => bootstrapFiling.value?.filing.header.status)
   const bootstrapNr = computed(() => bootstrapFiling.value?.filing[bootstrapFilingType.value]?.nameRequest)

--- a/src/stores/businessBootstrap.ts
+++ b/src/stores/businessBootstrap.ts
@@ -12,7 +12,7 @@ export const useBcrosBusinessBootstrap = defineStore('bcros/businessBootstrap', 
   const isStoreLoading = ref(false)
   const pendingFilings: Ref<PendingItemI[]> = ref([])
   const bootstrapIdentifier = computed(() => bootstrapFiling.value?.filing.business.identifier)
-  const bootstrapLegalType = computed(() => bootstrapFiling.value?.filing.business.legalType)
+  const bootstrapLegalType = computed(() => bootstrapFiling.value?.filing.business.legalType || bootstrapFiling.value?.filing?.incorporationApplication?.nameRequest?.legalType)
   const bootstrapFilingType = computed(() => bootstrapFiling.value?.filing.header.name)
   const bootstrapFilingStatus = computed(() => bootstrapFiling.value?.filing.header.status)
   const bootstrapNr = computed(() => bootstrapFiling.value?.filing[bootstrapFilingType.value]?.nameRequest)


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24661

*Description of changes:*
Change how legal type is looked at for bootstrap businesses. This fixes whatever is sending incorporation applications through without a business legal type in the business section of the filing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
