### PR TITLE
24679 - fix 'undefined' text in dialog for deleting IA and registration

### DIFF
--- a/src/components/bcros/todo/Item.vue
+++ b/src/components/bcros/todo/Item.vue
@@ -45,7 +45,10 @@ const confirmDeleteDraft: DialogOptionsI = {
 }
 
 const confirmDeleteApplication: DialogOptionsI = {
-  title: t('text.dialog.confirmDeleteApplication.title').replace('FILING_NAME', filingTypeToName(prop.item.name)),
+  title: t('text.dialog.confirmDeleteApplication.title').replace(
+    'FILING_NAME',
+    filingTypeToName(prop.item.name, undefined, undefined, prop.item.status as FilingStatusE)
+  ),
   text: t('text.dialog.confirmDeleteApplication.text').replace('DRAFT_TITLE', prop.item.draftTitle),
   textExtra: ['You will be returned to the Business Registry page.'], // TO-DO: different text for name request
   hideClose: true,

--- a/src/utils/todo/task-filing/content-loader.ts
+++ b/src/utils/todo/task-filing/content-loader.ts
@@ -105,7 +105,7 @@ export const getDraftTitle = (filing: TaskToDoI): string => {
     case FilingTypes.CONTINUATION_OUT:
       return FilingNames.CONTINUATION_OUT
     case FilingTypes.CONTINUATION_IN:
-      return FilingNames.CONTINUATION_IN_APPLICATION
+      return FilingNames.CONTINUATION_AUTHORIZATION
     case FilingTypes.CONVERSION:
       return FilingNames.CONVERSION
     case FilingTypes.CORRECTION:

--- a/src/utils/todo/task-filing/content-loader.ts
+++ b/src/utils/todo/task-filing/content-loader.ts
@@ -113,9 +113,9 @@ export const getDraftTitle = (filing: TaskToDoI): string => {
     case FilingTypes.DISSOLUTION:
       return filingTypeToName(FilingTypes.DISSOLUTION)
     case FilingTypes.INCORPORATION_APPLICATION:
-      return filing.displayName
+      return FilingNames.INCORPORATION_APPLICATION
     case FilingTypes.REGISTRATION:
-      return filing.displayName
+      return FilingNames.REGISTRATION
     case FilingTypes.RESTORATION:
       return filingTypeToName(FilingTypes.RESTORATION, null, filing.restoration.type)
     case FilingTypes.SPECIAL_RESOLUTION:


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24679

*Description of changes:*
1) the draftTitle fields for IA draft and Registration draft were not loaded correctly, resulting in the 'undefined' in the deletion confirmation dialog. 
- IA draft: https://business-dashboard-dev--pr-97-5obencu4.web.app/TnjrzwbLE8
- Registration draft: https://business-dashboard-dev--pr-97-5obencu4.web.app/T1F4aVE2Sb

2) Additional fix (not mentioned in ticket #24679): when deleting a continuation authorization draft, "Continuation Authorization" is the right term to use in the dialog. 
- https://business-dashboard-dev--pr-97-5obencu4.web.app/TuRq0uvoEq
- https://business-dashboard-dev--pr-97-5obencu4.web.app/TfiJx520Uy




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
