### PR TITLE
fix: multiple accountid in the query param

### DIFF
--- a/src/components/bcros/header/Index.vue
+++ b/src/components/bcros/header/Index.vue
@@ -89,7 +89,9 @@ const { createAccount, logout } = useBcrosAuth()
 function switchAccount (accountId: number) {
   account.switchCurrentAccount(accountId)
   // refresh the page so that account based checks are rerun
-  window.location.reload()
+  const url = new URL(window.location)
+  url.searchParams.set('accountid', accountId.toString())
+  window.location.assign(url.toString())
 }
 
 // logged out menu options

--- a/src/middleware/02.setupAuth.global.ts
+++ b/src/middleware/02.setupAuth.global.ts
@@ -36,7 +36,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     const account = useBcrosAccount()
     await account.setUserName()
     let accountNumber = to?.params?.accountid || to?.query?.accountid || undefined
-    if(Array.isArray(accountNumber)) {
+    if (Array.isArray(accountNumber)) {
       accountNumber = accountNumber[0]
     }
     await account.setAccountInfo(+accountNumber)

--- a/src/middleware/02.setupAuth.global.ts
+++ b/src/middleware/02.setupAuth.global.ts
@@ -35,7 +35,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
     // set account stuff (normally would happen after kc init in 'setupAuth')
     const account = useBcrosAccount()
     await account.setUserName()
-    const accountNumber = to?.params?.accountid || to?.query?.accountid || undefined
+    let accountNumber = to?.params?.accountid || to?.query?.accountid || undefined
+    if(Array.isArray(accountNumber)) {
+      accountNumber = accountNumber[0]
+    }
     await account.setAccountInfo(+accountNumber)
   }
 })

--- a/src/middleware/02.setupAuth.global.ts
+++ b/src/middleware/02.setupAuth.global.ts
@@ -35,6 +35,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     // set account stuff (normally would happen after kc init in 'setupAuth')
     const account = useBcrosAccount()
     await account.setUserName()
-    await account.setAccountInfo()
+    const accountNumber = to?.params?.accountid || to?.query?.accountid || undefined
+    await account.setAccountInfo(+accountNumber)
   }
 })


### PR DESCRIPTION
*Issue:24755*https://github.com/bcgov/entity/issues/24755

*Description of changes:*
fix: multiple accountid in the query param

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
