### PR TITLE
link breadcrumbs to allow for open in new window

### DIFF
--- a/src/components/bcros/Breadcrumb.vue
+++ b/src/components/bcros/Breadcrumb.vue
@@ -21,6 +21,7 @@
             :trailing="true"
             variant="link"
             data-cy="crumb-link"
+            :to="crumb.href ? crumb.href : crumb.to"
             @click="navigate(crumb)"
           >
             {{ crumb.text.value }}


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24584

*Description of changes:*
added the to value to the breadcrumbs so that they have a link value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
