### PR TITLE
Fix username display for BCeID users

### DIFF
--- a/src/composables/useBcrosAuth.ts
+++ b/src/composables/useBcrosAuth.ts
@@ -44,9 +44,12 @@ export const useBcrosAuth = () => {
           // successfully initialized so setup other pieces
           keycloak.syncSessionStorage()
           keycloak.scheduleRefreshToken()
+
           // set user info
-          console.info('Setting user name...')
-          await account.setUserName()
+          // NB. user name will be set automatically; calculated from the kcUser initialized in initKeyCloak function
+          // console.info('Setting user name...')
+          // await account.setUserName()
+
           // set account info
           console.info('Setting user account information...')
           await account.setAccountInfo(Number(currentAccountId))

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -13,8 +13,8 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   // user info
   const user = computed(() => keycloak.kcUser)
   const userAccounts: Ref<AccountI[]> = ref([])
-  const userFirstName: Ref<string> = ref(user.value?.firstName || '-')
-  const userLastName: Ref<string> = ref(user.value?.lastName || '')
+  const userFirstName = computed(() => user.value?.firstName || '-')
+  const userLastName = computed(() => user.value?.lastName || '')
   const userFullName = computed(() => `${userFirstName.value} ${userLastName.value}`)
   const isStaffAccount = computed(() => currentAccount.value.accountType === AccountTypeE.STAFF)
   // errors


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*
The username for BCeID user is not loaded properly (showing as 'undefined')
<img width="800" alt="image" src="https://github.com/user-attachments/assets/873b5ac3-cec7-4a3b-8600-17ef6d5e5225">

Problem resolved. See this screenshot taken from localhost
<img width="800" alt="image" src="https://github.com/user-attachments/assets/7dc1395d-7ffd-4c37-a092-f27c435bba05">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
