### PR TITLE
24842 - bypass name request loading for completed bootstrap filing

### DIFF
--- a/src/composables/useBcrosAuth.ts
+++ b/src/composables/useBcrosAuth.ts
@@ -45,11 +45,6 @@ export const useBcrosAuth = () => {
           keycloak.syncSessionStorage()
           keycloak.scheduleRefreshToken()
 
-          // set user info
-          // NB. user name will be set automatically; calculated from the kcUser initialized in initKeyCloak function
-          // console.info('Setting user name...')
-          // await account.setUserName()
-
           // set account info
           console.info('Setting user account information...')
           await account.setAccountInfo(Number(currentAccountId))

--- a/src/stores/businessBootstrap.ts
+++ b/src/stores/businessBootstrap.ts
@@ -105,7 +105,7 @@ export const useBcrosBusinessBootstrap = defineStore('bcros/businessBootstrap', 
   const linkedNr: Ref<NameRequestI> = ref(undefined)
 
   const bootstrapName = computed(() => {
-    if (bootstrapNrNumber.value) {
+    if (bootstrapNrNumber.value && (isBootstrapTodo.value || isBootstrapPending.value)) {
       // get approved name from the linked name request
       return linkedNr.value?.names.find(val => val.state === NameRequestStateE.APPROVED)?.name
     } else if (bootstrapNr?.value?.legalName) {
@@ -214,7 +214,7 @@ export const useBcrosBusinessBootstrap = defineStore('bcros/businessBootstrap', 
     if (!bootsrapCached || force) {
       isStoreLoading.value = true
       bootstrapFiling.value = await getBootstrapFiling(identifier)
-      if (bootstrapNrNumber.value) {
+      if (bootstrapNrNumber.value && (isBootstrapPending.value || isBootstrapTodo.value)) {
         await loadLinkedNameRequest(bootstrapNrNumber.value, force)
       }
       isStoreLoading.value = false


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*
When a bootstrap filing is completed (i.e. in Filing History), do not fetch NR. 

Example: 
https://business-dashboard-dev--pr-109-6wd9k1vn.web.app//THWqgK4Dnv

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
