### PR TITLE
24458 - no expansion panel for pending correction filing in the todo section

### DIFF
--- a/cypress/e2e/components/todos/pending.cy.ts
+++ b/cypress/e2e/components/todos/pending.cy.ts
@@ -174,4 +174,22 @@ context('TODOs -> Pending Filing', () => {
       .eq(0).click()
       .wait('@cancelPayment')
   })
+
+  it('Paid and pending correction', () => {
+    cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, 'pendingCorrection.json')
+
+    cy.get('[data-cy="header_todo"]').should('exist')
+    cy.get('[data-cy="todoItemList"]').should('exist')
+
+    // subtitle
+    cy.get('[data-cy^="todoItem-label-"]')
+      .should('exist')
+      .should('contains.text', 'FILING PENDING')
+
+    // no 'View Details' button
+    cy.get('[data-cy^="todoItem-showMore-"]').should('not.exist')
+
+    // no action button
+    cy.get('[data-cy^="todoItemActions-"]').find('button').should('not.exist')
+  })
 })

--- a/cypress/fixtures/todos/pendingCorrection.json
+++ b/cypress/fixtures/todos/pendingCorrection.json
@@ -1,0 +1,42 @@
+{
+  "tasks": [
+    {
+      "enabled": true,
+      "order": 1,
+      "task": {
+        "filing": {
+          "business": {
+            "foundingDate": "2024-10-12T00:27:29.366345+00:00",
+            "identifier": "BC0883617",
+            "legalName": "0883617 B.C. LTD.",
+            "legalType": "BC"
+          },
+          "correction": {
+            "correctedFilingType": "incorporationApplication"
+          },
+          "header": {
+            "affectedFilings": [],
+            "availableOnPaperOnly": false,
+            "certifiedBy": "",
+            "colinIds": [],
+            "comments": [],
+            "date": "2024-12-11T21:51:10.469453+00:00",
+            "deletionLocked": false,
+            "effectiveDate": "2024-12-11T21:51:10.469477+00:00",
+            "filingId": 155015,
+            "folioNumber": "",
+            "inColinOnly": false,
+            "isCorrected": false,
+            "isCorrectionPending": false,
+            "name": "correction",
+            "priority": false,
+            "paymentStatusCode": "COMPLETED",
+            "status": "PENDING",
+            "submitter": "pewang@idir",
+            "waiveFees": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/utils/todo/task-filing/content-loader.ts
+++ b/src/utils/todo/task-filing/content-loader.ts
@@ -183,8 +183,7 @@ export const addExpansionContent = (todoItem: TodoItemI): void => {
     // if it is a draft correction filing
     todoItem.expansionContent = TodoExpansionContentE.DRAFT_CORRECTION
   } else if (todoItem.name === FilingTypes.CORRECTION) {
-    // if it is a correction filing (non-draft)
-    todoItem.expansionContent = TodoExpansionContentE.CORRECTION
+    // if it is a non-draft correction filing (pending filing), no expansion panel in this case
   } else if (
     (todoItem.status === FilingStatusE.DRAFT || todoItem.status === FilingStatusE.APPROVED) && todoItem.nameRequest
   ) {


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24458

*Description of changes:*
When there is a pending correction in the todo section, no expansion panel should be displayed and there should be no 'view detail' button. 

It is hard to reproduce because a correction filing is added to the filing history right after the filing is submitted. 
Cypress test is used to mock this scenario. See screenshot below:
<img width="1009" alt="pending correction" src="https://github.com/user-attachments/assets/194b919b-f0aa-4458-805e-d8e37f2f9fc9" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
