### PR TITLE
24821 - fix for no documents on expanded screen.

### DIFF
--- a/src/components/bcros/filing/CommonTemplate.vue
+++ b/src/components/bcros/filing/CommonTemplate.vue
@@ -107,15 +107,20 @@ if (filing.value.commentsCount && filing.value.commentsLink) {
 const isStatusPaid = computed(() => isFilingStatus(filing.value, FilingStatusE.PAID))
 const isStatusApproved = computed(() => isFilingStatus(filing.value, FilingStatusE.APPROVED))
 
-const url = useRequestURL()
-const expandedFilingId = url.searchParams.get('filing_id')
-const isShowBody = ref(expandedFilingId && expandedFilingId === filing?.value?.filingId?.toString())
+const isShowBody = ref(false)
 
 const showDetails = () => {
   if (filing.value.documents === undefined && filing.value.documentsLink) {
     loadDocumentList(filing.value)
   }
   isShowBody.value = !isShowBody.value
+}
+
+// auto expand item if expandedFilingId is in URL & item is not expanded
+const url = useRequestURL()
+const expandedFilingId = url.searchParams.get('filing_id')
+if (!isShowBody.value && expandedFilingId && expandedFilingId === filing?.value?.filingId?.toString()) {
+  showDetails()
 }
 
 /** The title of this filing. */


### PR DESCRIPTION
*Issue:24821 *https://github.com/bcgov/entity/issues/24821 

*Description of changes:*
fix: documents not loaded when filing expanded via URL query param

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
