### PR TITLE
25125 - download error dialog

### DIFF
--- a/cypress/e2e/components/filings/section.cy.ts
+++ b/cypress/e2e/components/filings/section.cy.ts
@@ -45,7 +45,7 @@ context('Filings history section', () => {
     cy.get('[data-cy="download-document-button-Receipt"]').should('exist')
     cy.get('[data-cy="download-document-button-downloadAll"]').should('exist')
 
-    // intercet the download request and stub the response
+    // intercept the download request and stub the response
     cy.intercept('GET', '**/api/v2/businesses/**/filings/**/documents/receipt', (req) => {
       req.on('response', (res) => {
         // Wait for 1000 milliseconds before sending the response to the client.

--- a/cypress/e2e/components/filings/section.cy.ts
+++ b/cypress/e2e/components/filings/section.cy.ts
@@ -45,9 +45,17 @@ context('Filings history section', () => {
     cy.get('[data-cy="download-document-button-Receipt"]').should('exist')
     cy.get('[data-cy="download-document-button-downloadAll"]').should('exist')
 
+    // intercet the download request and stub the response
+    cy.intercept('GET', '**/api/v2/businesses/**/filings/**/documents/receipt', (req) => {
+      req.on('response', (res) => {
+        // Wait for 1000 milliseconds before sending the response to the client.
+        res.setDelay(1000)
+      })
+      req.reply({ statusCode: 200 })
+    }).as('downloadDocument')
+
     // download a single file, all document download buttons should be disabled
-    cy.intercept('GET', '**/api/v2/businesses/**/filings/**/documents/receipt').as('downloadDocument')
-      .get('[data-cy="download-document-button-Receipt"]').click()
+    cy.get('[data-cy="download-document-button-Receipt"]').click()
       .get('[data-cy="download-document-button-Director Change"]').should('be.disabled')
       .get('[data-cy="download-document-button-Notice Of Articles"]').should('be.disabled')
       .get('[data-cy="download-document-button-Receipt"]').should('be.disabled')

--- a/cypress/e2e/error-flows/download-error.cy.ts
+++ b/cypress/e2e/error-flows/download-error.cy.ts
@@ -1,0 +1,30 @@
+import { directorChange } from '../../fixtures/filings/directorChange/directorChange'
+
+context('Download Error', () => {
+  it('verify the document download error dialog occur when downloading fails', () => {
+    const filings = [directorChange]
+    cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, undefined, filings)
+    cy.fixture('filings/directorChange/documentList.json').then((response) => {
+      cy.intercept(
+        'GET',
+        `**/api/v2/businesses/**/filings/${directorChange.filingId}/documents`,
+        response).as('directorChangeDocumentList')
+    })
+
+    // expand filing
+    cy.get(`[data-cy="filingHistoryItem-default-filing-${directorChange.filingId}"]`)
+      .find('[data-cy="filing-main-action-button"]')
+      .click()
+      .wait('@directorChangeDocumentList')
+
+    // simulate download error
+    cy.intercept('GET', '**/api/v2/businesses/**/filings/**/documents/receipt', { statusCode: 500 })
+      .as('downloadError')
+    
+    // attempt to download a file; the error dialog should appear
+    cy.get('[data-cy="download-document-button-Receipt"]').click()
+      .wait('@downloadError')
+      .get('[data-cy="bcros-dialog-downloadError"]').should('exist')
+      .should('contain.text', 'Unable to Download Document')
+  })
+})

--- a/cypress/e2e/error-flows/download-error.cy.ts
+++ b/cypress/e2e/error-flows/download-error.cy.ts
@@ -1,7 +1,7 @@
 import { directorChange } from '../../fixtures/filings/directorChange/directorChange'
 
 context('Download Error', () => {
-  it('verify the document download error dialog occur when downloading fails', () => {
+  it('verify the document download error dialog when downloading fails', () => {
     const filings = [directorChange]
     cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, undefined, filings)
     cy.fixture('filings/directorChange/documentList.json').then((response) => {

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -137,7 +137,7 @@ const downloadBusinessSummary = async (): Promise<void> => {
     }
   } catch (error) {
     console.error('Failed to download business summary.', error)
-    // TO-DO: #25125 - show the download error dialog
+    ui.showDownloadingErrorDialog = true
   }
   ui.fetchingData = false
 }

--- a/src/components/bcros/dialog/CardedModal.vue
+++ b/src/components/bcros/dialog/CardedModal.vue
@@ -45,10 +45,10 @@
       <template #footer>
         <!-- can be replaced with <template v-slot:buttons> -->
         <slot name="buttons" :options="options">
-          <div class="flex justify-center gap-5">
+          <div class="flex gap-5" :class="options.buttons.length > 1 ? 'justify-between' : 'justify-end'">
             <div v-for="button, i in options.buttons" :key="'dialog-btn-' + i">
               <slot :name="'dialog-btn-slot-' + button.slotId">
-                <dialog-button :button="button" data-cy="bcros-dialog-btn" @close="emit('close')" />
+                <dialog-button variant="link" :button="button" data-cy="bcros-dialog-btn" @close="emit('close')" />
               </slot>
             </div>
           </div>

--- a/src/components/bcros/filing/CommonTemplate.vue
+++ b/src/components/bcros/filing/CommonTemplate.vue
@@ -116,7 +116,6 @@ const showDetails = async () => {
 
     await loadDocumentList(filing.value).catch((error) => {
       console.error('Failed to load the document list.', error)
-      // TO-DO: #25125 - show the download error dialog
     })
 
     // make the spinner display for another 250ms so it does not flash when the promise resolves quickly

--- a/src/components/bcros/filing/common/HeaderActions.vue
+++ b/src/components/bcros/filing/common/HeaderActions.vue
@@ -337,7 +337,6 @@ const handleButtonClick = async () => {
 
     await loadDocumentList(filing.value).catch((error) => {
       console.error('Failed to load the document list.', error)
-      // TO-DO: #25125 - show the download error dialog
     })
 
     // make the spinner display for another 250ms so it does not flash when the promise resolves quickly

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -47,7 +47,8 @@
       "ok": "OK",
       "change": "Change",
       "dismiss": "Dismiss",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "close": "Close"
     },
     "dialog": {
       "delete": "Delete",
@@ -205,7 +206,13 @@
       "error": {
         "contact": "If this issue persists, please contact us.",
         "default": "The Business Dashboard application is currently unavailable. Please try again later.",
-        "download": "File cannot be downloaded due to an application error. Please try again later.",
+        "downloadError": {
+          "title": "Unable to Download Document",
+          "text": {
+            "unableToDownload": "We were unable to download your document(s).",
+            "contact": "If this error persists, please contact us."
+          }
+        },
         "authorizeAffiliationsError": {
           "title": "Error updating affiliation invitation.",
           "text": "An error happened while updating affiliation invitation."
@@ -478,8 +485,7 @@
     "dialog": {
       "error": {
         "access": "Business Dashboard Access Denied",
-        "default": "Business Dashboard Unavailable",
-        "download": "Unable to download file"
+        "default": "Business Dashboard Unavailable"
       },
       "coa": "Address Change Effective 12:01 am",
       "correction": "Correction Filing",

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -18,6 +18,7 @@ const { todos } = storeToRefs(useBcrosTodos())
 const { getPendingCoa } = useBcrosFilings()
 const { filings } = storeToRefs(useBcrosFilings())
 const { pendingFilings } = storeToRefs(useBcrosBusinessBootstrap())
+const ui = useBcrosDashboardUi()
 
 const hasDirector = computed(() => {
   if (currentParties.value?.parties && currentParties.value?.parties.length > 0) {
@@ -281,6 +282,25 @@ const coaEffectiveDate = computed(() => {
           {{ $t('text.dialog.coa.continue') }}
         </UButton>
       </div>
+    </template>
+  </BcrosDialogCardedModal>
+
+  <BcrosDialogCardedModal
+    name="downloadError"
+    :display="ui.showDownloadingErrorDialog"
+    :options="getDownloadFileError()"
+    @close="() => ui.showDownloadingErrorDialog = false"
+  >
+    <template #content>
+      <p class="mb-4">
+        {{ $t('text.dialog.error.downloadError.text.unableToDownload') }}
+      </p>
+      <template v-if="!isStaffAccount">
+        <p>
+          {{ $t('text.dialog.error.downloadError.text.contact') }}
+        </p>
+        <BcrosContactInfo :contacts="getContactInfo('registries')" class="mt-5" />
+      </template>
     </template>
   </BcrosDialogCardedModal>
 

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -15,10 +15,12 @@ export const useBcrosDashboardUi = defineStore('bcros/dashboardUi', () => {
 
   const dashboardIsLoading = computed(() => uiIsLoading.value.length > 0)
   const fetchingData = ref(false)
+  const showDownloadingErrorDialog = ref(false)
 
   return {
     dashboardIsLoading,
     fetchingData,
+    showDownloadingErrorDialog,
     trackUiLoadingStart,
     trackUiLoadingStop
   }

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -90,7 +90,6 @@ export const loadDocumentList = async (filing: ApiResponseFilingI) => {
       // set property to null to retry next time
       filing.documents = null
       console.error('loadDocumentList() error =', error)
-      // FUTURE: enable some error dialog?
     }
   }
 }
@@ -132,6 +131,11 @@ export const saveBlob = (blob: any, fileName: string) => {
 
 /** Download the file as the given filename. */
 export const downloadFile = async (document: DocumentI) => {
-  const doc = await fetchDocuments(document.link)
-  saveBlob(doc, document.filename)
+  try {
+    const doc = await fetchDocuments(document.link)
+    saveBlob(doc, document.filename)
+  } catch (error) {
+    console.error('file downloading error =', error)
+    useBcrosDashboardUi().showDownloadingErrorDialog = true
+  }
 }

--- a/src/utils/error-dialog-options/download-file-error.ts
+++ b/src/utils/error-dialog-options/download-file-error.ts
@@ -1,8 +1,9 @@
 export function getDownloadFileError(): DialogOptionsI {
   const t = useNuxtApp().$i18n.t
   return {
-    buttons: [{ onClickClose: true, text: t('button.general.ok') }],
-    text: t('text.dialog.error.download'),
-    title: t('title.dialog.error.download')
+    buttons: [{ onClickClose: true, text: t('button.general.close') }],
+    text: '',
+    title: t('text.dialog.error.downloadError.title'),
+    hideClose: true
   }
 }


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25125

*Description of changes:*
Add a dialog for download error for:
- downloading business summary
- downloading a document from filing history

Screenshots
<img width="800" alt="download_error_non-staff" src="https://github.com/user-attachments/assets/8720eed2-b19b-4f55-9dd1-0cf7d5ab42ce" />
<img width="800" alt="download_error_staff" src="https://github.com/user-attachments/assets/f743d74e-f699-4132-9eb8-d6fe3918e452" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
