### PR TITLE
24779 - fix 'unknown' reason for historical business

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/businessDetails/Status.vue
+++ b/src/components/bcros/businessDetails/Status.vue
@@ -72,7 +72,7 @@ const getReasonText = computed(() => {
   } else {
     reason = t(`filing.name.${filingType}`)
     if (reason === `filing.name.${filingType}`) {
-      reason = t('filing.name.unknown`)')
+      reason = t('filing.name.unknown')
     }
   }
   return `${reason} ${enDash} ${date}`


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/24779

*Description of changes:*
The i18n text for "Unknown" was not displayed properly for unknown reason of a historical business.

When a business is historical and the filing type is "putBackOff" (e.g. Put back off filing due to expired limited restoration), the historical reason is "Unknown". 

Example in Dev: https://dev.business-dashboard.bcregistry.gov.bc.ca/BC0872094
![image](https://github.com/user-attachments/assets/a8c0a7da-2508-4b53-a86d-fa97aa5e86b4)

In temp url: https://business-dashboard-dev--pr-122-zvwusqwp.web.app/BC0872094
![image](https://github.com/user-attachments/assets/d13a64e7-bc70-470e-a8dc-197e198e34e8)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
