### PR TITLE
25406 - Use getStoredFlag to fetch Enable-Withdrawal-Action flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/filing/common/HeaderActions.vue
+++ b/src/components/bcros/filing/common/HeaderActions.vue
@@ -98,7 +98,7 @@ import { z } from 'zod'
 import { type ApiResponseFilingI, FilingStatusE, isFilingStatus, isStaffFiling, isFutureEffective } from '#imports'
 import { FilingCorrectionTypesE } from '~/enums/filing-correction-types-e'
 
-const { getFeatureFlag, getStoredFlag } = useBcrosLaunchdarkly()
+const { getStoredFlag } = useBcrosLaunchdarkly()
 const { hasRoleStaff } = storeToRefs(useBcrosKeycloak())
 const { isAllowedToFile, isBaseCompany, isDisableNonBenCorps, isEntityCoop, isEntityFirm } = useBcrosBusiness()
 const { currentBusiness } = storeToRefs(useBcrosBusiness())
@@ -325,7 +325,7 @@ const goToNoticeOfWithdrawal = () => {
 }
 
 const disableWithdrawal = (): boolean => {
-  const ff = getFeatureFlag('enable-withdrawal-action')
+  const ff = getStoredFlag('enable-withdrawal-action')
   return !(hasRoleStaff && isFutureEffectiveFiling.value && ff)
 }
 


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25406

*Description of changes:*
- Using `getStoredFlag `instead of `getFeatureFlag` as per https://github.com/bcgov/business-dashboard-ui/pull/127#:~:text=Yes%2C%20I%20believe%20that%20it%20would%20be%20better%20if%20getStoredFlag%20is%20used%20here%2C%20I%20do%20not%20think%20we%20used%20getFeatureFlag%20inside%20the%20vue%20files.%20It%20basically%20lets%20you%20retrieve%20flag%20(if%20loaded%20in%20the%20store)%20even%20if%20the%20ldclient%20is%20down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
