### PR TITLE
25157 - close the comment modal after saving comments/details

### DIFF
--- a/cypress/e2e/components/filings/correctionFilings.cy.ts
+++ b/cypress/e2e/components/filings/correctionFilings.cy.ts
@@ -1,4 +1,5 @@
 import { allFilings } from '../../../fixtures/filings/allFilings'
+import { administrativeDissolution } from '../../../fixtures/filings/dissolution/administrativeDissolution'
 import { devBCReg } from '../../../fixtures/origins'
 
 context('Correction Filings', () => {
@@ -34,12 +35,15 @@ context('Correction Filings', () => {
   })
 
   it("Staff shouldn't be able to file a correction against an invalid type", () => {
-    cy.visitBusinessDashFor('businessInfo/ben/active.json', undefined, false, false, undefined, allFilings, true)
+    cy.visitBusinessDashFor(
+      'businessInfo/ben/active.json', undefined, false, false, undefined, [administrativeDissolution], true
+    )
     cy.intercept('POST', '**/api/v2/businesses/**/filings', {}).as('correctionFilingsPost')
 
     cy.get('[data-cy="header.actions.dropdown"]').should('exist')
-    // select filing 3 (administrative dissolution) and the correction option should be disabled
-    cy.get('[data-cy="header.actions.dropdown"]').eq(3).click()
+
+    // open the dropdown for the administrative dissolution in the Filing History; correction option should be disabled
+    cy.get('[data-cy="header.actions.dropdown"]').first().click()
     cy.get('[data-cy="header.actions.dropdown"] .fileACorrection').should('have.attr', 'aria-disabled')
     cy.get('[data-cy="header.actions.dropdown"] .fileACorrection').invoke('attr', 'aria-disabled').should('eq', 'true')
   })

--- a/cypress/e2e/components/filings/correctionFilings.cy.ts
+++ b/cypress/e2e/components/filings/correctionFilings.cy.ts
@@ -38,8 +38,8 @@ context('Correction Filings', () => {
     cy.intercept('POST', '**/api/v2/businesses/**/filings', {}).as('correctionFilingsPost')
 
     cy.get('[data-cy="header.actions.dropdown"]').should('exist')
-    //select filing 2 instead of 0 or 1 which are correctionable
-    cy.get('[data-cy="header.actions.dropdown"]').eq(2).click()
+    // select filing 3 (administrative dissolution) and the correction option should be disabled
+    cy.get('[data-cy="header.actions.dropdown"]').eq(3).click()
     cy.get('[data-cy="header.actions.dropdown"] .fileACorrection').should('have.attr', 'aria-disabled')
     cy.get('[data-cy="header.actions.dropdown"] .fileACorrection').invoke('attr', 'aria-disabled').should('eq', 'true')
   })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -257,7 +257,7 @@ const contacts = getContactInfo('registries')
         <BcrosComment :comments="comments" :business="currentBusiness.identifier" @close="showCommentDialog(false)" />
       </UModal>
       <UButton
-        id="download-summary-button"
+        id="comment-button"
         small
         text
         variant="ghost"

--- a/src/components/bcros/comment/Index.vue
+++ b/src/components/bcros/comment/Index.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<{
   showCloseModal: true
 })
 
-defineEmits(['close'])
+const emit = defineEmits(['close'])
 
 const MAX_COMMENT_LENGTH = 2000
 const commentToAdd = ref('')
@@ -76,6 +76,7 @@ const saveComment = async () => {
 
   commentToAdd.value = ''
   noChangesSinceSave.value = true
+  emit('close')
 }
 
 </script>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25157

*Description of changes:*
- We use the same modal to add comments and details. The modal does not close when the 'save' button is clicked. The issue is fixed in this PR
![image](https://github.com/user-attachments/assets/43394ff0-a42e-48d4-b2de-dcb116f9d0af)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
