### PR TITLE
26211 Updated Keycloak dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",
@@ -32,7 +32,7 @@
     "country-list": "^2.3.0",
     "http-status-codes": "^2.3.0",
     "iso-3166-2": "^1.0.0",
-    "keycloak-js": "^24.0.4",
+    "keycloak-js": "^26.2.0",
     "launchdarkly-vue-client-sdk": "^2.2.0",
     "lodash.isdate": "^4.0.1",
     "lodash.isequal": "^4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       keycloak-js:
-        specifier: ^24.0.4
-        version: 24.0.4
+        specifier: ^26.2.0
+        version: 26.2.0
       launchdarkly-vue-client-sdk:
         specifier: ^2.2.0
         version: 2.2.0(vue@3.4.27(typescript@5.4.5))
@@ -3630,9 +3630,6 @@ packages:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
 
-  js-sha256@0.11.0:
-    resolution: {integrity: sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3721,8 +3718,8 @@ packages:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
 
-  keycloak-js@24.0.4:
-    resolution: {integrity: sha512-eLjG7CzGGgAXh78M76QUJy1R8+QDQvIJXJf6T3bq9VJZ6RXBGZXMsXvII66b83ueYDFa1gi2JojmA31Z23HO0g==}
+  keycloak-js@26.2.0:
+    resolution: {integrity: sha512-CrFcXTN+d6J0V/1v3Zpioys6qHNWE6yUzVVIsCUAmFn9H14GZ0vuYod+lt+SSpMgWGPuneDZBSGBAeLBFuqjsw==}
 
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -10422,8 +10419,6 @@ snapshots:
 
   js-cookie@3.0.5: {}
 
-  js-sha256@0.11.0: {}
-
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.0: {}
@@ -10514,12 +10509,10 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  jwt-decode@4.0.0: {}
+  jwt-decode@4.0.0:
+    optional: true
 
-  keycloak-js@24.0.4:
-    dependencies:
-      js-sha256: 0.11.0
-      jwt-decode: 4.0.0
+  keycloak-js@26.2.0: {}
 
   keygrip@1.1.0:
     dependencies:


### PR DESCRIPTION
*Issue:* bcgov/entity#26211

*Description of changes:*
- app version = 1.0.22
- updated Keycloak JS dependency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).