### PR TITLE
25222-removing nbsp that was causing extra space in limited restoration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/filing/item/LimitedRestoration.vue
+++ b/src/components/bcros/filing/item/LimitedRestoration.vue
@@ -5,7 +5,7 @@
         <strong>{{ $t('text.filing.restoration.limitedRestorationPeriod') }}</strong>
 
         <p class="mt-4">
-          {{ $t('text.general.the') }}&nbsp;{{ $t('text.general.company') }}&nbsp;
+          {{ $t('text.general.the') }}&nbsp;{{ $t('text.general.company') }}
           <strong>{{ currentBusinessName }}</strong>
           {{ $t('text.filing.restoration.wasSuccessfullyRestored') }}
           <strong>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25222

*Description of changes:*
Removed nbsp from message build that was inserting a second space in sentence.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
