### PR TITLE
25649 remove deprecated ff

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -25,11 +25,6 @@ const { goToCreateUI } = useBcrosNavigate()
 const ui = useBcrosDashboardUi()
 const filings = useBcrosFilings()
 
-const isAllowedBusinessSummary = computed(() =>
-  !!currentBusinessIdentifier.value &&
-  !!getStoredFlag('supported-business-summary-entities')?.includes(currentBusiness.value.legalType)
-)
-
 const isPendingDissolution = computed(() => {
   return false
   // todo: implement !!FUTURE not implemented in current dashboard
@@ -332,7 +327,7 @@ const contacts = getContactInfo('registries')
     </div>
 
     <!-- Download Business Summary -->
-    <div v-if="!isDisableNonBenCorps() && isAllowedBusinessSummary">
+    <div v-if="!isDisableNonBenCorps()">
       <BcrosTooltip
         :text="$t('tooltip.filing.button.businessSummary')"
         :popper="{

--- a/src/stores/business.ts
+++ b/src/stores/business.ts
@@ -313,9 +313,7 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
       }
 
       case AllowableActionE.BUSINESS_SUMMARY: {
-        // NB: specific entities are targeted via LaunchDarkly
-        const ff = !!getFeatureFlag('supported-business-summary-entities')?.includes(legalType)
-        return (ff && isBusiness)
+        return (isBusiness)
       }
 
       case AllowableActionE.CONSENT_AMALGAMATION_OUT: {

--- a/src/stores/dashboardActions.ts
+++ b/src/stores/dashboardActions.ts
@@ -119,9 +119,7 @@ export const useBcrosDashboardActions = defineStore('bcros/dashboardActions', ()
       }
 
       case AllowableActionE.BUSINESS_SUMMARY: {
-        // NB: specific entities are targeted via LaunchDarkly
-        const ff = !!getFeatureFlag('supported-business-summary-entities')?.includes(legalType)
-        return (ff && isBusiness)
+        return (isBusiness)
       }
 
       case AllowableActionE.CONSENT_AMALGAMATION_OUT: {


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25649

Removed explicit calls to the "supported-business-summary-entities". Left in the cases for AllowableActionE.BUSINESS_SUMMARY - I could not see this used anywhere else, but I was worried stripping it may cause issues. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
