### PR TITLE
26368 - After a COA is withdrawn, don't show Pending badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -252,20 +252,13 @@ const alerts = computed((): Array<Partial<AlertI>> => {
 })
 
 const pendingAddress = computed(() => {
-  const currentDate = new Date()
-  if (filings && filings.value && filings.value.length > 0) {
-    const coaFilings = filings.value.filter((filing) => {
-      return (filing.name === FilingTypes.CHANGE_OF_ADDRESS) && (filing.status !== FilingStatusE.WITHDRAWN)
-    })
-    coaFilings.sort((a, b) => {
-      return new Date(b.effectiveDate) - new Date(a.effectiveDate)
-    })
-    const coaFiling = coaFilings[0]
-    if (coaFiling?.effectiveDate && new Date(coaFiling?.effectiveDate) > currentDate) {
-      return true
-    }
-  }
-  return false
+  if (!filings?.value?.length) { return false }
+
+  // Return true if the COA is pending
+  return filings.value.some(filing =>
+    filing.name === FilingTypes.CHANGE_OF_ADDRESS &&
+    filing.status === FilingStatusE.PAID
+  )
 })
 
 const showChangeOfAddress = ref(false)

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -255,7 +255,7 @@ const pendingAddress = computed(() => {
   const currentDate = new Date()
   if (filings && filings.value && filings.value.length > 0) {
     const coaFilings = filings.value.filter((filing) => {
-      return filing.name === FilingTypes.CHANGE_OF_ADDRESS
+      return (filing.name === FilingTypes.CHANGE_OF_ADDRESS) && (filing.status !== FilingStatusE.WITHDRAWN)
     })
     coaFilings.sort((a, b) => {
       return new Date(b.effectiveDate) - new Date(a.effectiveDate)


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/26368

*Description of changes:*
- After a COA is withdrawn, it shouldn't show the Pending badge and tooltip
- Fix the pendingAddress condition to exclude withdrawn COA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
