### PR TITLE
26499 fixed redirects with missing accountId

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -21,7 +21,7 @@ const { hasRoleStaff } = useBcrosKeycloak()
 const { isAllowedToFile, isDisableNonBenCorps } = useBcrosBusiness()
 const isCommentOpen = ref(false)
 const isDissolutionDialogOpen = ref(false)
-const { goToCreateUI } = useBcrosNavigate()
+const { goToCreateUI, goToEditUI } = useBcrosNavigate()
 const ui = useBcrosDashboardUi()
 const filings = useBcrosFilings()
 
@@ -105,18 +105,15 @@ const promptChangeBusinessInfo = () => {
     return
   }
 
-  const baseUrl = useRuntimeConfig().public.editURL
-  const editUrl = `${baseUrl}/${currentBusinessIdentifier.value}`
-
   if (!currentBusiness.value.goodStanding && !hasRoleStaff) {
     alert('change company info')
     // this.emitNotInGoodStanding(NigsMessage.CHANGE_COMPANY_INFO)
   } else if (currentBusiness.value.legalType === CorpTypeCd.COOP) {
-    navigateTo(`${editUrl}/special-resolution`, { external: true })
+    goToEditUI(`/${currentBusiness.value.identifier}/special-resolution`)
   } else if (isFirm.value) {
-    navigateTo(`${editUrl}/change`, { external: true })
+    goToEditUI(`/${currentBusiness.value.identifier}/change`)
   } else {
-    navigateTo(`${editUrl}/alteration`, { external: true })
+    goToEditUI(`/${currentBusiness.value.identifier}/alteration`)
   }
 }
 

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -7,7 +7,7 @@ const t = useNuxtApp().$i18n.t
 const business = useBcrosBusiness()
 const { currentParties, currentBusinessAddresses, currentBusiness, isHistorical } = storeToRefs(business)
 
-const { goToEditUI } = useBcrosNavigate()
+const { goToEditUI, goToFilingsUI } = useBcrosNavigate()
 
 const { isStaffAccount } = useBcrosAccount()
 
@@ -268,16 +268,12 @@ const setChangeOfAddress = (show: boolean) => {
 }
 
 const goToStandaloneAddresses = () => {
-  const baseUrl = useRuntimeConfig().public.filingsURL
-  const url = `${baseUrl}/${business.currentBusinessIdentifier}/standalone-addresses?filingId=0`
-  navigateTo(url, { external: true })
+  goToFilingsUI(`/${business.currentBusinessIdentifier}/standalone-addresses`, { filingId: '0' })
 }
 
 const changeAddress = () => {
   if (business.isEntityFirm()) {
-    const baseUrl = useRuntimeConfig().public.editURL
-    const url = `${baseUrl}/${business.currentBusinessIdentifier}/change`
-    navigateTo(url, { external: true })
+    goToEditUI(`/${currentBusiness.value.identifier}/change`)
   } else if (business.isBaseCompany()) {
     setChangeOfAddress(true)
   } else {
@@ -285,17 +281,11 @@ const changeAddress = () => {
   }
 }
 
-const goToStandaloneDirectors = () => {
-  const baseUrl = useRuntimeConfig().public.filingsURL
-  const url = `${baseUrl}/${business.currentBusinessIdentifier}/standalone-directors?filingId=0`
-  navigateTo(url, { external: true })
-}
-
 const changePartyInfo = () => {
   if (business.isEntityFirm()) {
     goToEditUI(`/${currentBusiness.value.identifier}/change`)
   } else {
-    goToStandaloneDirectors()
+    goToFilingsUI(`/${business.currentBusinessIdentifier}/standalone-directors`, { filingId: '0' })
   }
 }
 

--- a/src/stores/filings.ts
+++ b/src/stores/filings.ts
@@ -79,7 +79,7 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
     })
   }
 
-  const createFiling = (business: BusinessI, filingType: FilingTypes, params: any, draft?: boolean) => {
+  const createFiling = (business: BusinessI, filingType: FilingTypes, params: any, draft?: boolean): any => {
     const url = `${apiURL}/businesses/${business.identifier}/filings${draft ? '?draft=true' : ''}`
     const currDate = new Date()
     const month = currDate.getMonth() + 1


### PR DESCRIPTION
*Issue:* bcgov/entity#26499

*Description of changes:*
- app version = 1.0.32
- changed navigateTo to goToEditUi or goToFilingsUi
- added a type to fix a lint warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).