### PR TITLE
26369 - Load State Filing on Dashboard Refresh 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -195,6 +195,7 @@ const reloadBusinessInfo = async () => {
 
   // reload business info using the force=true flag
   await loadBusinessInfo(true)
+  await business.loadStateFiling(true)
 }
 
 onBeforeMount(async () => {

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -193,7 +193,7 @@ const reloadBusinessInfo = async () => {
   useBcrosFilings().clearFilings()
   // TO-DO: also need to clear the pending filing list (not yet implemented)
 
-  // reload business info using the force=true flag
+  // reload business info and state filing using the force=true flag
   await loadBusinessInfo(true)
   await business.loadStateFiling(true)
 }

--- a/src/stores/business.ts
+++ b/src/stores/business.ts
@@ -525,6 +525,7 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
     loadBusinessContact,
     loadBusinessAddresses,
     loadParties,
+    loadStateFiling,
     isEntityCoop,
     isLegalType,
     isEntityFirm,


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/26369 

*Description of changes:*
- The bug happens in an intermediate stage when the state filing is not updated, however, once you **reload** the page (and the state filing is updated), you see the correct status & reasoning shown (i.e. if you go to the corp in the ticket, you'll see the correct status: 
![image](https://github.com/user-attachments/assets/415b0b96-bf5b-4230-aae9-8f69db54fbd8)
)
- Solution: force the state filing to be updated on **refresh** (when you click the button that appears on the toast) to ensure the status shown is up-to-date

https://github.com/user-attachments/assets/f09a9a1f-7535-4c7b-a05d-ec1fc9e1255d


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
