### PR TITLE
26471 added App Name header

### DIFF
--- a/cypress/e2e/components/addresses.cy.ts
+++ b/cypress/e2e/components/addresses.cy.ts
@@ -65,6 +65,7 @@ context('Business dashboard -> Address side component', () => {
 
   it('Change button does not exist for historical businesses', () => {
     cy.visitBusinessDashFor('businessInfo/bc/historical.json')
+    cy.wait(1000)
     cy.get('[data-cy="address-change-button"]').should('not.exist')
   })
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/plugins/bcros-fetch.ts
+++ b/src/plugins/bcros-fetch.ts
@@ -33,6 +33,10 @@ export default defineNuxtPlugin(() => {
       if (!headerExists(headers, 'Accept')) {
         addHeader(headers, 'Accept', 'application/json')
       }
+
+      if (!headerExists(headers, 'App-Name')) {
+        addHeader(headers, 'App-Name', useRuntimeConfig().public.appNameDisplay)
+      }
     }
   })
 


### PR DESCRIPTION
*Issue:* bcgov/entity#26471

I did the same as #3298 and used the verbose app name and not the package name:
![image](https://github.com/user-attachments/assets/00ae4465-6595-4ef7-83ff-66afb573a3b0)

*Description of changes:*
- app version = 1.0.34
- added App Name header to all fetch calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).