### PR TITLE
26719 Allow corrections to paper-only filings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/app/router.options.ts
+++ b/src/app/router.options.ts
@@ -15,7 +15,7 @@ export default <RouterConfig> {
       beforeEnter(to, _from, next) {
         // If identifier is missing
         if (!to.params.identifier) {
-          next({ name: RouteNameE.DASHBOARD, params: { identifier: 'default_identifier' } })
+          next({ name: RouteNameE.DASHBOARD, params: { identifier: 'XXX' } })
         } else {
           next()
         }

--- a/src/components/bcros/filing/common/HeaderActions.vue
+++ b/src/components/bcros/filing/common/HeaderActions.vue
@@ -87,8 +87,6 @@
     <UModal v-model="isCommentOpen" :ui="{base: 'absolute left-10 top-5 bottom-5'}">
       <BcrosComment :comments="filing.comments" :filing="filing" @close="showCommentDialog(false)" />
     </UModal>
-
-    <BcrosLoadingModal :open="loadingDocuments" />
   </div>
 </template>
 
@@ -220,11 +218,6 @@ const disableCorrection = (): boolean => {
     !!getStoredFlag('supported-correction-entities')?.includes(currentBusiness.value?.legalType) &&
     isAllowedToFile(FilingTypes.CORRECTION)
   if (!isAllowed) {
-    return true
-  }
-
-  // disable if filing is paper-only
-  if (filing.value.availableOnPaperOnly) {
     return true
   }
 


### PR DESCRIPTION
*Issue:* bcgov/entity#26719

*Description of changes:*
- app version = 1.0.37
- changed default identifier to XXX (error handling)
- deleted obsolete modal instance
- allow corrections to paper-only filings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).