### PR TITLE
26578 - feat: disable business summary for certain corp types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.37",
+  "version": "1.0.38  git st",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.38  git st",
+  "version": "1.0.38",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -26,10 +26,9 @@ const ui = useBcrosDashboardUi()
 const filings = useBcrosFilings()
 
 const isAllowedBusinessSummary = computed(() => {
-    const supportedEntities = getStoredFlag('supported-business-summary-entities')?.split(' ')
-    return !!currentBusinessIdentifier.value && supportedEntities?.includes(currentBusiness?.value?.legalType)
-  }
-)
+  const supportedEntities = getStoredFlag('supported-business-summary-entities')?.split(' ')
+  return !!currentBusinessIdentifier.value && supportedEntities?.includes(currentBusiness?.value?.legalType)
+})
 
 const businessSummaryTooltipText = computed(
   () => isAllowedBusinessSummary.value

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -25,9 +25,10 @@ const { goToCreateUI, goToEditUI } = useBcrosNavigate()
 const ui = useBcrosDashboardUi()
 const filings = useBcrosFilings()
 
-const isAllowedBusinessSummary = computed(() =>
-  !!currentBusinessIdentifier.value &&
-  !!getStoredFlag('supported-business-summary-entities')?.includes(currentBusiness.value.legalType)
+const isAllowedBusinessSummary = computed(() => {
+    const supportedEntities = getStoredFlag('supported-business-summary-entities')?.split(' ')
+    return !!currentBusinessIdentifier.value && supportedEntities?.includes(currentBusiness?.value?.legalType)
+  }
 )
 
 const businessSummaryTooltipText = computed(

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -30,13 +30,13 @@ const isAllowedBusinessSummary = computed(() => {
   return !!currentBusinessIdentifier.value && supportedEntityTypes?.includes(currentBusiness?.value?.legalType)
 })
 
-const isCurrentlyDisabledBusinessSummary = computed(() => {
-  const disabledEntityTypes = getStoredFlag('disabled-business-summary-entities')?.split(' ')
+const isCurrentlyEnabledBusinessSummary = computed(() => {
+  const disabledEntityTypes = getStoredFlag('enabled-business-summary-entities')?.split(' ')
   return !!disabledEntityTypes?.includes(currentBusiness?.value?.legalType)
 })
 
 const businessSummaryTooltipText = computed(
-  () => isAllowedBusinessSummary.value && !isCurrentlyDisabledBusinessSummary.value
+  () => isAllowedBusinessSummary.value && isCurrentlyEnabledBusinessSummary.value
     ? t('tooltip.filing.button.businessSummary')
     : t('tooltip.filing.button.businessSummaryDisabled')
 )
@@ -340,7 +340,7 @@ const contacts = getContactInfo('registries')
     </div>
 
     <!-- Download Business Summary -->
-    <div v-if="!isDisableNonBenCorps() && !!isAllowedBusinessSummary">
+    <div v-if="!isDisableNonBenCorps() && isAllowedBusinessSummary">
       <BcrosTooltip
         :text="businessSummaryTooltipText"
         :popper="{
@@ -352,7 +352,7 @@ const contacts = getContactInfo('registries')
           id="download-summary-button"
           small
           text
-          :disabled="isCurrentlyDisabledBusinessSummary"
+          :disabled="!isCurrentlyEnabledBusinessSummary"
           variant="ghost"
           class="w-full text-nowrap"
           data-cy="button.downloadSummary"

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -340,7 +340,7 @@ const contacts = getContactInfo('registries')
     </div>
 
     <!-- Download Business Summary -->
-    <div v-if="!!currentBusinessIdentifier && isAllowedBusinessSummary">
+    <div v-if="!isDisableNonBenCorps() && !!isAllowedBusinessSummary">
       <BcrosTooltip
         :text="businessSummaryTooltipText"
         :popper="{

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -26,12 +26,17 @@ const ui = useBcrosDashboardUi()
 const filings = useBcrosFilings()
 
 const isAllowedBusinessSummary = computed(() => {
-  const supportedEntities = getStoredFlag('supported-business-summary-entities')?.split(' ')
-  return !!currentBusinessIdentifier.value && supportedEntities?.includes(currentBusiness?.value?.legalType)
+  const supportedEntityTypes = getStoredFlag('supported-business-summary-entities')?.split(' ')
+  return !!currentBusinessIdentifier.value && supportedEntityTypes?.includes(currentBusiness?.value?.legalType)
+})
+
+const isCurrentlyDisabledBusinessSummary = computed(() => {
+  const disabledEntityTypes = getStoredFlag('disabled-business-summary-entities')?.split(' ')
+  return !!disabledEntityTypes?.includes(currentBusiness?.value?.legalType)
 })
 
 const businessSummaryTooltipText = computed(
-  () => isAllowedBusinessSummary.value
+  () => isAllowedBusinessSummary.value && !isCurrentlyDisabledBusinessSummary.value
     ? t('tooltip.filing.button.businessSummary')
     : t('tooltip.filing.button.businessSummaryDisabled')
 )
@@ -335,7 +340,7 @@ const contacts = getContactInfo('registries')
     </div>
 
     <!-- Download Business Summary -->
-    <div>
+    <div v-if="!!currentBusinessIdentifier && isAllowedBusinessSummary">
       <BcrosTooltip
         :text="businessSummaryTooltipText"
         :popper="{
@@ -347,7 +352,7 @@ const contacts = getContactInfo('registries')
           id="download-summary-button"
           small
           text
-          :disabled="isDisableNonBenCorps() || !isAllowedBusinessSummary"
+          :disabled="isCurrentlyDisabledBusinessSummary"
           variant="ghost"
           class="w-full text-nowrap"
           data-cy="button.downloadSummary"

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -30,6 +30,12 @@ const isAllowedBusinessSummary = computed(() =>
   !!getStoredFlag('supported-business-summary-entities')?.includes(currentBusiness.value.legalType)
 )
 
+const businessSummaryTooltipText = computed(
+  () => isAllowedBusinessSummary.value
+    ? t('tooltip.filing.button.businessSummary')
+    : t('tooltip.filing.button.businessSummaryDisabled')
+)
+
 const isPendingDissolution = computed(() => {
   return false
   // todo: implement !!FUTURE not implemented in current dashboard
@@ -329,9 +335,9 @@ const contacts = getContactInfo('registries')
     </div>
 
     <!-- Download Business Summary -->
-    <div v-if="!isDisableNonBenCorps() && isAllowedBusinessSummary">
+    <div>
       <BcrosTooltip
-        :text="$t('tooltip.filing.button.businessSummary')"
+        :text="businessSummaryTooltipText"
         :popper="{
           placement: 'top',
           arrow: true
@@ -341,6 +347,7 @@ const contacts = getContactInfo('registries')
           id="download-summary-button"
           small
           text
+          :disabled="isDisableNonBenCorps() || !isAllowedBusinessSummary"
           variant="ghost"
           class="w-full text-nowrap"
           data-cy="button.downloadSummary"

--- a/src/components/bcros/businessDetails/Links.vue
+++ b/src/components/bcros/businessDetails/Links.vue
@@ -31,8 +31,8 @@ const isAllowedBusinessSummary = computed(() => {
 })
 
 const isCurrentlyEnabledBusinessSummary = computed(() => {
-  const disabledEntityTypes = getStoredFlag('enabled-business-summary-entities')?.split(' ')
-  return !!disabledEntityTypes?.includes(currentBusiness?.value?.legalType)
+  const enabledEntityTypes = getStoredFlag('enabled-business-summary-entities')?.split(' ')
+  return !!enabledEntityTypes?.includes(currentBusiness?.value?.legalType)
 })
 
 const businessSummaryTooltipText = computed(

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -609,6 +609,7 @@
     "filing": {
       "button": {
         "businessSummary": "View and download a summary of information about the business.",
+        "businessSummaryDisabled": "Business Summaries are coming soon. Access them via BC OnLine or email bcregistries{'@'}gov.bc.ca for request information.",
         "colinLink": "BC Limited Companies are managed in Corporate Online.",
         "isPendingDissolution": "You cannot view or change business information while the business is pending dissolution."
       }


### PR DESCRIPTION


*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*
- disable business summary for certain corp types and their continuation in countrerparts (BC, CC, ULC)
- update tooltip to match.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
