### PR TITLE
26644 - Set Business Dashboard Page Title to Company Name

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,7 +4,7 @@ export default defineNuxtConfig({
   app: {
     buildAssetsDir: '/src/',
     head: {
-      title: 'BC Business Registry',
+      title: 'Business Dashboard',
       htmlAttrs: { dir: 'ltr' },
       link: [{ rel: 'icon', type: 'image/ico', href: '/favicon.ico' }]
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -200,6 +200,9 @@ const reloadBusinessInfo = async () => {
 
 onBeforeMount(async () => {
   await loadBusinessInfo()
+  useHead({
+    title: currentBusiness.value?.legalName || bootstrap.bootstrapName
+  })
 })
 
 const alerts = computed((): Array<Partial<AlertI>> => {


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/26644 

*Description of changes:*
- Set the Business Dashboard page title to the Company Name
- Set the global title to "Business Dashboard"
- Update app version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
