### PR TITLE
26644 - Fix Page Title for SP and GP

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -201,7 +201,7 @@ const reloadBusinessInfo = async () => {
 onBeforeMount(async () => {
   await loadBusinessInfo()
   useHead({
-    title: currentBusiness.value?.legalName || bootstrap.bootstrapName
+    title: business.currentBusinessName || bootstrap.bootstrapName
   })
 })
 


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/26644

*Description of changes:*
During testing it was discovered that a value different from the expected legal name was being displayed for SP and GP:
![image](https://github.com/user-attachments/assets/806e6d72-f5ae-4556-a442-a198c413884c)

Now using the computed `currentBusinessName` property instead as it accounts for the alternate names for SP and GP.
![image](https://github.com/user-attachments/assets/d3353706-6ffa-4fc6-bc58-fcf6a18c20bd)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
