### PR TITLE
25048 add staff link now always displayed for staff

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
-    "chromeWebSecurity": false, // To avoid CORS issues.
     setupNodeEvents (on) {
       on('task', {
         log (message) {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
+    "chromeWebSecurity": false, // To avoid CORS issues.
     setupNodeEvents (on) {
       on('task', {
         log (message) {

--- a/cypress/e2e/components/addresses.cy.ts
+++ b/cypress/e2e/components/addresses.cy.ts
@@ -65,7 +65,7 @@ context('Business dashboard -> Address side component', () => {
 
   it('Change button does not exist for historical businesses', () => {
     cy.visitBusinessDashFor('businessInfo/bc/historical.json')
-    cy.wait(1000)
+    cy.wait(2000)
     cy.get('[data-cy="address-change-button"]').should('not.exist')
   })
 

--- a/cypress/e2e/components/addresses.cy.ts
+++ b/cypress/e2e/components/addresses.cy.ts
@@ -2,8 +2,7 @@ import { addressChange } from '../../fixtures/filings/addressChange/completed.ts
 
 context('Business dashboard -> Address side component', () => {
   it('Address accordion is rendered for Registered Office and Record Office', () => {
-    cy.visitBusinessDash('BC0871427', 'BEN')
-
+    cy.visitBusinessDashFor('businessInfo/ben/active.json')
     // the accordion exists
     cy.get('[data-cy="accordion_officeAddresses"]').should('exist')
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -154,13 +154,17 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Set the user account list and current account */
-  async function setAccountInfo (currentAccountId?: number) {
+  async function setAccountInfo (currentAccountId = NaN) {
     // Check if we have a currentAccountId and if it matches what is stored in our sessionStorage
-    if (!currentAccountId ||
+    if (isNaN(currentAccountId) ||
       (JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)) &&
       currentAccountId !== JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)).id)) {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
+      // refresh the page so that account based checks are rerun
+      const url = new URL(window.location)
+      url.searchParams.set('accountid', currentAccountId.toString())
+      window.location.assign(url.toString())
     }
     if (user.value?.keycloakGuid) {
       userAccounts.value = await getUserAccounts(user.value?.keycloakGuid) || []

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -1,8 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import type { ProductCodeE } from '#imports'
 import { AccountAccessError } from '~/interfaces/error-i'
-import { GetCorpNumberedDescription } from '@bcrs-shared-components/corp-type-module'
-import { ExitStatus } from 'typescript'
 
 /** Manages bcros account data */
 export const useBcrosAccount = defineStore('bcros/account', () => {
@@ -167,29 +165,26 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       if (userAccounts && userAccounts.value.length > 0) {
         currentAccount.value = userAccounts.value[0]
         // If we have an accountid that matches in our current account switch to that
-        if (currentAccountId && userAccounts.value.find(account => account.id === currentAccountId)) { 
-          // if previous current account id selection information available set this as current account
+        if (currentAccountId && userAccounts.value.find(account => account.id === currentAccountId)) {
           currentAccount.value = userAccounts.value.find(account => account.id === currentAccountId) || {} as AccountI
-        } 
-        // Make sure the currentAccountId we retrieved from the query string matches the currentAccountId
+        }
         sessionStorage.setItem(SessionStorageKeyE.CURRENT_ACCOUNT, JSON.stringify(currentAccount.value))
 
         // If we set a new currentAccountId, change it in the URL and reload.
-        if( currentAccountId !== queryAccountId || currentAccountId !== Number(currentAccount.value.id) ) {
+        if (currentAccountId !== queryAccountId || currentAccountId !== Number(currentAccount.value.id)) {
           // currentAccount takes precedent over any other number.
           currentAccountId = Number(currentAccount.value.id)
-          const url = new URL(window.location)
+          const url = new URL(window.location.href)
+          url.searchParams.delete('accountid')
           url.searchParams.set('accountid', currentAccountId.toString())
-          // window.location.assign(url.toString())
-        } 
+          // Cypress is not happy if we reload the page, so avoid that here.
+          if (!sessionStorage.getItem('FAKE_CYPRESS_LOGIN')) {
+            window.location.assign(url.href)
+          }
+        }
       }
     }
-    // If we have tried unsuccessfully to get an account, set currentAccount to a blank.
-    if(currentAccountId === undefined) {
-      currentAccount.value = {} as AccountI
-    }
   }
-
 
   /** Switch the current account to the given account ID if it exists in the user's account list */
   function switchCurrentAccount (accountId: number) {

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -155,7 +155,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
 
   /** Set the user account list and current account */
   async function setAccountInfo (currentAccountId?: number) {
-    //Check if we have a currentAccountId and if it matches what is stored in our sessionStorage
+    // Check if we have a currentAccountId and if it matches what is stored in our sessionStorage
     if (!currentAccountId ||
       (JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)) &&
       currentAccountId !== JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)).id)) {

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -162,7 +162,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
       // if we have an accountid now, refresh the page so that account based checks are rerun
-      if(currentAccountId && !isNaN(currentAccountId)) {
+      if (currentAccountId && !isNaN(currentAccountId)) {
         const url = new URL(window.location)
         url.searchParams.set('accountid', currentAccountId.toString())
         window.location.assign(url.toString())

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -161,10 +161,12 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       currentAccountId !== JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)).id)) {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
-      // refresh the page so that account based checks are rerun
-      const url = new URL(window.location)
-      url.searchParams.set('accountid', currentAccountId.toString())
-      window.location.assign(url.toString())
+      // if we have an accountid now, refresh the page so that account based checks are rerun
+      if(currentAccountId && !isNaN(currentAccountId)) {
+        const url = new URL(window.location)
+        url.searchParams.set('accountid', currentAccountId.toString())
+        window.location.assign(url.toString())
+      }
     }
     if (user.value?.keycloakGuid) {
       userAccounts.value = await getUserAccounts(user.value?.keycloakGuid) || []

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -154,9 +154,9 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Set the user account list and current account */
-  async function setAccountInfo (currentAccountId = undefined) {
+  async function setAccountInfo (currentAccountId: number) {
     const queryAccountId = currentAccountId
-    if (currentAccountId === undefined) {
+    if (isNaN(currentAccountId)) {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
     }

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -155,7 +155,10 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
 
   /** Set the user account list and current account */
   async function setAccountInfo (currentAccountId?: number) {
-    if (!currentAccountId) {
+    //Check if we have a currentAccountId and if it matches what is stored in our sessionStorage
+    if (!currentAccountId ||
+      (JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)) &&
+      currentAccountId !== JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT)).id)) {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
     }

--- a/src/stores/business.ts
+++ b/src/stores/business.ts
@@ -77,11 +77,10 @@ export const useBcrosBusiness = defineStore('bcros/business', () => {
         if (error.value || !data.value) {
           console.warn('Error fetching business details for', identifier)
           errors.value.push({
-            statusCode: error.value?.statusCode || StatusCodes.INTERNAL_SERVER_ERROR,
+            statusCode: error.value?.status || StatusCodes.INTERNAL_SERVER_ERROR,
             message: error.value?.data?.message,
             category: ErrorCategoryE.ENTITY_BASIC
           })
-          return null
         }
         return data.value?.business
       })


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25048

Update so that we check account id query value against account id session value when setting up user on the dashboard. Assumed that session account id takes precedence. This addresses case where incorrect query param was overriding proper account id which caused issues with loading the proper account data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
