### PR TITLE
29900 use payment date if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/filing/common/FiledLabel.vue
+++ b/src/components/bcros/filing/common/FiledLabel.vue
@@ -2,21 +2,21 @@
   <template v-if="isTypeStaff">
     <span v-if="putBackOnOrAdminDissolution">
       ({{ $t('text.filing.filedBy') }} {{ filing.submitter }} {{ $t('text.filing.on') }}
-      <BcrosTooltipDate :date="filing.submittedDate" />)
+      <BcrosTooltipDate :date="filedAndPaidDate" />)
       <BcrosDivider class="ml-1 mr-2" />
       {{ $t('text.filing.effectiveAsOf').toString() }}
       <BcrosTooltipDate :date="filing.effectiveDate" />
     </span>
     <span v-else>
       {{ capitalizedFiledBy }} {{ filing.submitter }} {{ $t('text.filing.on') }}
-      <BcrosTooltipDate :date="filing.submittedDate" />
+      <BcrosTooltipDate :date="filedAndPaidDate" />)
     </span>
   </template>
 
   <template v-else>
     <span>
       ({{ $t('text.filing.filedBy') }} {{ filing.submitter }} {{ $t('text.filing.on') }}
-      <BcrosTooltipDate :date="filing.submittedDate" />)
+      <BcrosTooltipDate :date="filedAndPaidDate" />)
     </span>
     <span v-if="showEffectiveAs">
       <BcrosDivider class="ml-1 mr-2" />
@@ -45,6 +45,11 @@ const isTypeStaff = computed(() => isStaffFiling(props.filing))
 const putBackOnOrAdminDissolution = computed(
   () => isFilingType(props.filing, FilingTypes.PUT_BACK_ON) ||
     isFilingType(props.filing, undefined, FilingSubTypeE.DISSOLUTION_ADMINISTRATIVE)
+)
+
+/** Date to use for Filed and Paid. */
+const filedAndPaidDate = computed(
+  () => props.filing.paymentDate || props.filing.submittedDate
 )
 
 const showEffectiveAs = computed(() => {

--- a/src/components/bcros/filing/common/FiledLabel.vue
+++ b/src/components/bcros/filing/common/FiledLabel.vue
@@ -9,7 +9,7 @@
     </span>
     <span v-else>
       {{ capitalizedFiledBy }} {{ filing.submitter }} {{ $t('text.filing.on') }}
-      <BcrosTooltipDate :date="filedAndPaidDate" />)
+      <BcrosTooltipDate :date="filedAndPaidDate" />
     </span>
   </template>
 

--- a/src/components/bcros/filing/common/HeaderActions.vue
+++ b/src/components/bcros/filing/common/HeaderActions.vue
@@ -161,7 +161,7 @@ const correctionFormSubmit = async function () {
     FilingTypes.CORRECTION,
     {
       comment: '',
-      correctedFilingDate: dateToYyyyMmDd(new Date(filing.value.submittedDate)),
+      correctedFilingDate: dateToYyyyMmDd(new Date(filing.value.paymentDate || filing.value.submittedDate)),
       correctedFilingId: filingId.value,
       correctedFilingType: filing.value.name,
       type: correctionType

--- a/src/components/bcros/filing/common/filedAnd/Rejected.vue
+++ b/src/components/bcros/filing/common/filedAnd/Rejected.vue
@@ -6,7 +6,7 @@
     <BcrosDivider class="mx-2" />
     <span>
       {{ $t('text.filing.submittedBy') }} {{ filing.submitter }} {{ $t('text.filing.on') }}
-      <BcrosTooltipDate :date="filing.submittedDate" />
+      <BcrosTooltipDate :date="filing.paymentDate || filing.submittedDate" />
     </span>
   </div>
 </template>

--- a/src/components/bcros/filing/item/DissolutionVoluntary.vue
+++ b/src/components/bcros/filing/item/DissolutionVoluntary.vue
@@ -20,7 +20,11 @@ const actTitle = computed(() => businessConfig.value?.dissolutionConfirmation?.a
 
 /** The dissolution date-time submitted to display. */
 const dissolutionDateSubmittedPacific =
-  props.filing.submittedDate ? dateToPacificDateTime(new Date(props.filing.submittedDate)) : unknownStr
+  props.filing.paymentDate
+    ? dateToPacificDateTime(new Date(props.filing.paymentDate))
+    : props.filing.submittedDate
+      ? dateToPacificDateTime(new Date(props.filing.submittedDate))
+      : unknownStr
 /** The dissolution date to display. */
 const dissolutionDateIso = props.filing.data?.dissolution?.dissolutionDate
 const date = yyyyMmDdToDate(dissolutionDateIso)

--- a/src/interfaces/filing-i.ts
+++ b/src/interfaces/filing-i.ts
@@ -48,7 +48,6 @@ export interface ApiResponseFilingI {
   displayName: string
   displayLedger: boolean // whether to display this ledger item
   documentsLink: string // URL to fetch this filing's documents
-  // effectiveDate: ApiDateTimeUtc
   effectiveDate: FormattedDateTimeGmt,
   filingId: number
   filingLink: string // URL to fetch this filing

--- a/src/interfaces/filing-i.ts
+++ b/src/interfaces/filing-i.ts
@@ -56,7 +56,7 @@ export interface ApiResponseFilingI {
   isFutureEffective: boolean
   name: FilingTypes
   status: FilingStatusE
-  // submittedDate: ApiDateTimeUtc,
+  paymentDate?: FormattedDateTimeGmt,
   submittedDate: FormattedDateTimeGmt,
   submitter: string
   withdrawalPending: boolean

--- a/src/interfaces/state-filing-i.ts
+++ b/src/interfaces/state-filing-i.ts
@@ -1,6 +1,6 @@
 import { FilingTypes } from '@bcrs-shared-components/enums'
-
 import { FilingStatusE } from '~/enums/filing-status-e'
+import type { ApiDateTimeUtc, FormattedDateTimeGmt } from '@bcrs-shared-components/interfaces'
 
 export interface StateFilingHeaderI {
   accountId?: number // NOT USED
@@ -12,7 +12,7 @@ export interface StateFilingHeaderI {
   comments: any[]
   commentsCount: number
   commentsLink: string
-  date: string // submitted date
+  date: ApiDateTimeUtc // submitted date
   documentsLink: string
   effectiveDate: string // FUTURE: is this obsolete?
   email?: string // FUTURE: is this obsolete?
@@ -23,6 +23,7 @@ export interface StateFilingHeaderI {
   isCorrectionPending: boolean
   isFutureEffective: boolean // FUTURE: is this obsolete?
   name: FilingTypes
+  paymentDate?: FormattedDateTimeGmt,
   paymentMethod?: any
   paymentStatusCode?: string
   paymentToken?: any // NB: may be UUID in future

--- a/src/interfaces/state-filing-i.ts
+++ b/src/interfaces/state-filing-i.ts
@@ -1,6 +1,6 @@
 import { FilingTypes } from '@bcrs-shared-components/enums'
-import { FilingStatusE } from '~/enums/filing-status-e'
 import type { ApiDateTimeUtc, FormattedDateTimeGmt } from '@bcrs-shared-components/interfaces'
+import { FilingStatusE } from '~/enums/filing-status-e'
 
 export interface StateFilingHeaderI {
   accountId?: number // NOT USED

--- a/src/interfaces/tasks-i.ts
+++ b/src/interfaces/tasks-i.ts
@@ -1,5 +1,6 @@
 import { FilingTypes } from '@bcrs-shared-components/enums'
-import type { AlterationIF, SpecialResolutionIF } from '@bcrs-shared-components/interfaces'
+import type { AlterationIF, ApiDateTimeUtc, FormattedDateTimeGmt, SpecialResolutionIF }
+  from '@bcrs-shared-components/interfaces'
 
 export interface TaskApiHeaderI {
   accountId?: number // NOT USED
@@ -11,7 +12,7 @@ export interface TaskApiHeaderI {
   comments: any[]
   commentsCount: number
   commentsLink: string
-  date: string // submitted date
+  date: ApiDateTimeUtc // submitted date
   documentsLink: string
   effectiveDate: string // FUTURE: is this obsolete?
   email?: string // FUTURE: is this obsolete?
@@ -22,6 +23,7 @@ export interface TaskApiHeaderI {
   isCorrectionPending: boolean
   isFutureEffective: boolean // FUTURE: is this obsolete?
   name: FilingTypes
+  paymentDate?: FormattedDateTimeGmt,
   paymentMethod?: any
   paymentStatusCode?: string
   paymentToken?: any // NB: may be UUID in future

--- a/src/stores/filings.ts
+++ b/src/stores/filings.ts
@@ -159,7 +159,7 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
       isFutureEffective: header.isFutureEffective,
       name: header.name,
       status: header.status,
-      submittedDate: apiToUtcString(header.date),
+      submittedDate: header.paymentDate || apiToUtcString(header.date),
       submitter: header.submitter,
       withdrawalPending: bootstrapFiling.withdrawalPending,
       data: {
@@ -194,7 +194,7 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
           isFutureEffective: false,
           name: header.name,
           status: header.status,
-          submittedDate: apiToUtcString(header.date),
+          submittedDate: header.paymentDate || apiToUtcString(header.date),
           submitter: header.submitter,
           data: {
             applicationDate: dateToYyyyMmDd(apiToDate(header.date)),

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -57,7 +57,7 @@ export const loadDocumentList = async (filing: ApiResponseFilingI) => {
                   title = camelCaseToWords(legalFiling)
                 }
               }
-              const date = dateToYyyyMmDd(new Date(filing.submittedDate))
+              const date = dateToYyyyMmDd(new Date(filing.paymentDate || filing.submittedDate))
               const identifier = currentBusinessIdentifier.value || filing.businessIdentifier
               const filename = `${identifier} ${title} - ${date}.pdf`
               const link = legalFilings[legalFiling]
@@ -81,7 +81,7 @@ export const loadDocumentList = async (filing: ApiResponseFilingI) => {
         } else if (groupName === 'letterOfConsentAmalgamationOut') {
           // this is a special case for Amalgamation Out Letter of Consent
           const title = 'Letter of Consent'
-          const date = dateToYyyyMmDd(new Date(filing.submittedDate))
+          const date = dateToYyyyMmDd(new Date(filing.paymentDate || filing.submittedDate))
           const identifier = currentBusinessIdentifier.value || filing.businessIdentifier
           const filename = `${identifier} ${title} - ${date}.pdf`
           const link = fetchedDocuments[groupName] as string
@@ -89,7 +89,7 @@ export const loadDocumentList = async (filing: ApiResponseFilingI) => {
         } else {
           // this is a submission level output
           const title = camelCaseToWords(groupName)
-          const date = dateToYyyyMmDd(new Date(filing.submittedDate))
+          const date = dateToYyyyMmDd(new Date(filing.paymentDate || filing.submittedDate))
           const identifier = currentBusinessIdentifier.value || filing.businessIdentifier
           const filename = `${identifier} ${title} - ${date}.pdf`
           const link = fetchedDocuments[groupName] as string


### PR DESCRIPTION
*Issue:* bcgov/entity#29900

*Description of changes:*
- app version = 1.1.10
- updated "filed by" date to be paymentDate if it exists, else fall back to submittedDate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).