### PR TITLE
30724 Hide effective time for COD

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/filing/common/FiledLabel.vue
+++ b/src/components/bcros/filing/common/FiledLabel.vue
@@ -25,7 +25,7 @@
     <span v-if="showEffectiveAs">
       <BcrosDivider class="ml-1 mr-2" />
       {{ $t('text.filing.effectiveAsOf').toString() }}
-      <BcrosTooltipDate :date="filing.effectiveDate" />
+      <BcrosTooltipDate :date="filing.effectiveDate" :hide-tooltip="hideTooltip" />
     </span>
   </template>
 </template>
@@ -65,5 +65,10 @@ const showEffectiveAs = computed(() => {
   ]
   const isWithdrawn = props.filing.status === FilingStatusE.WITHDRAWN
   return !dontShow.includes(props.filing.name) && !isWithdrawn
+})
+
+/** Whether to hide the tooltip (which effectively hides the effective time). */
+const hideTooltip = computed(() => {
+  return isFilingType(props.filing, FilingTypes.CHANGE_OF_DIRECTORS)
 })
 </script>

--- a/src/components/bcros/tooltip/Date.vue
+++ b/src/components/bcros/tooltip/Date.vue
@@ -1,5 +1,9 @@
 <template>
+  <span v-if="hideTooltip" class="font-13">
+    {{ dateToPacificDate(displayDate) }}
+  </span>
   <BcrosTooltip
+    v-else
     :text="dateToPacificDateTime(displayDate)"
     :popper="{
       placement: 'right',
@@ -13,10 +17,11 @@
 </template>
 
 <script setup lang="ts">
-import { dateToPacificDateTime } from '#imports'
+import { dateToPacificDate, dateToPacificDateTime } from '#imports'
 
 const props = defineProps({
-  date: { type: String, required: true }
+  date: { type: String, required: true },
+  hideTooltip: { type: Boolean, default: false }
 })
 
 const displayDate = computed(() => new Date(props.date))


### PR DESCRIPTION
*Issue:* bcgov/entity#30724

*Description of changes:*
- app version 1.1.19
- added special case to hide tooltip for COD
- updated BcrosTooltipDate to conditionally hide tooltip

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).

Before:
<img width="922" height="107" alt="image" src="https://github.com/user-attachments/assets/49892354-78b1-401c-b5d4-62d8d837e9af" />

After:
<img width="921" height="103" alt="image" src="https://github.com/user-attachments/assets/eabfe9db-9a04-4c6a-b9c5-ec39c215d933" />

The above design change was approved by Janis.