### PR TITLE
33005 update consent to continue out text 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",
@@ -68,6 +68,5 @@
     "node": ">=24"
   }
 }
-
 
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -192,7 +192,7 @@
         "ceaseLiquidator": "Cease Liquidator",
         "ceaseReceiver": "Cease Receiver",
         "consentToAmalgamateOut": "Consent to Amalgamate Out",
-        "consentToContinueOut": "Consent to Continuation Out",
+        "consentToContinueOut": "Consent to Continue Out",
         "continueOut": "Continue Out",
         "courtOrder": "Add Court Order",
         "delayDissolution": "Delay of Dissolution",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -622,6 +622,7 @@
       "ceaseReceiver": "Notice of Ceasing to Act as Receiver or Receiver Manager",
       "changeAddressReceiver": "Notice of Receiver Change of Address Filing"
     },
+    "consentContinuationOut": "Consent to Continue Out",
     "continuationIn": "Continuation Application",
     "continuationAuthorization": "Continuation Authorization",
     "conversion": "Record Conversion",
@@ -668,7 +669,7 @@
       "changeOfName": "Legal Name Change",
       "changeOfRegistration": "Change of Registration",
       "consentAmalgamationOut": "Consent to Amalgamation Out",
-      "consentContinuationOut": "Consent to Continuation Out",
+      "consentContinuationOut": "Consent to Continue Out",
       "continuationInApplication": "Continuation In Application",
       "continuationOut": "Continuation Out",
       "conversion": "Record Conversion",

--- a/src/utils/todo/task-filing/content-loader.ts
+++ b/src/utils/todo/task-filing/content-loader.ts
@@ -45,7 +45,7 @@ export const getTitle = (filing: TaskToDoI, corpFullDescription: string): string
     case FilingTypes.CONSENT_AMALGAMATION_OUT:
       return FilingNames.CONSENT_AMALGAMATION_OUT
     case FilingTypes.CONSENT_CONTINUATION_OUT:
-      return FilingNames.CONSENT_CONTINUATION_OUT
+      return filingTypeToName(FilingTypes.CONSENT_CONTINUATION_OUT)
     case FilingTypes.CONTINUATION_OUT:
       return FilingNames.CONTINUATION_OUT
     case FilingTypes.CONTINUATION_IN:
@@ -116,7 +116,7 @@ export const getDraftTitle = (filing: TaskToDoI): string => {
     case FilingTypes.CHANGE_OF_REGISTRATION:
       return FilingNames.CHANGE_OF_REGISTRATION
     case FilingTypes.CONSENT_CONTINUATION_OUT:
-      return FilingNames.CONSENT_CONTINUATION_OUT
+      return filingTypeToName(FilingTypes.CONSENT_CONTINUATION_OUT)
     case FilingTypes.CONTINUATION_OUT:
       return FilingNames.CONTINUATION_OUT
     case FilingTypes.CONTINUATION_IN:


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/33005

*Description of changes:*
- **`src/lang/en.json`**
  Added `filingTypes.consentContinuationOut: "Consent to Continue Out"` so the filing type has a user-friendly display label. This aligns with the existing `filing.name.consentContinuationOut` wording instead of falling back to the auto-generated `"Consent Continuation Out"`.

- **`src/utils/todo/task-filing/content-loader.ts`**  
  Updated both `CONSENT_CONTINUATION_OUT` cases (in `getTitle` and `getDraftTitle`) to use `filingTypeToName(...)` instead of the hard-coded `FilingNames.CONSENT_CONTINUATION_OUT` enum value (`"Consent to Continuation Out"`).  

  This ensures the To Do row title is resolved through i18n and picks up the new label, keeping it consistent with how `CONTINUATION_IN` and `RESTORATION` are already handled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
