### PR TITLE
34029-registrars-notation-certifiedby

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",
@@ -68,5 +68,3 @@
     "node": ">=24"
   }
 }
-
-

--- a/src/stores/filings.ts
+++ b/src/stores/filings.ts
@@ -122,8 +122,7 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
       filing: {
         header: {
           name: filingType,
-          date: currDate.getFullYear() + '-' + monthStr + '-' + dayStr,
-          certifiedBy: ''
+          date: currDate.getFullYear() + '-' + monthStr + '-' + dayStr
         },
         business: {
           identifier: business.identifier,

--- a/src/types/create-filing.ts
+++ b/src/types/create-filing.ts
@@ -1,7 +1,7 @@
 export type FilingHeaderT = {
   name: string,
   date: string,
-  certifiedBy: string
+  certifiedBy?: string
 }
 
 export type FilingBusinessT = {


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/34029

*Description of changes:*
Removes the empty certifiedBy from the staff filing header so Registrar's Notation/Order and other staff filings no longer fail with a 422,

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
