### PR TITLE
34065 - filings history bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bcros-business-dashboard",
   "private": true,
   "type": "module",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "scripts": {
     "build": "nuxt generate",
     "build:local": "nuxt build",

--- a/src/components/bcros/filing/List.vue
+++ b/src/components/bcros/filing/List.vue
@@ -29,6 +29,7 @@ defineProps({
 })
 
 const { currentBusiness } = storeToRefs(useBcrosBusiness())
+const { loading: filingsLoading } = storeToRefs(useBcrosFilings())
 
 const hasCourtOrders = computed(() => currentBusiness.value?.hasCourtOrders)
 
@@ -84,35 +85,50 @@ const filingComponent = (filing: ApiResponseFilingI): Component => {
     class="flex flex-col gap-1.5 bg-gray-100"
     data-cy="FilingHistoryList"
   >
-    <!-- Court order notification -->
+    <!-- loading display while the filing history is fetched -->
     <div
-      v-if="hasCourtOrders"
-      class="flex flex-row gap-2 w-full bg-white p-5 rounded mb-5 items-center"
-      data-cy="hasCourtOrdersNotificationCard"
+      v-if="filingsLoading"
+      class="flex flex-col gap-1.5 w-full"
+      data-cy="filing-history-loading"
     >
-      <UIcon name="i-mdi-gavel" class="text-xl text-black" />
-      <span class="ml-1 text-base">{{ $t('text.filing.courtOrder.hasCourtOrders') }}</span>
+      <div v-for="i in 3" :key="i" class="flex flex-col gap-3 w-full bg-white p-5 rounded">
+        <USkeleton class="h-5 w-1/3" />
+        <USkeleton class="h-4 w-1/2" />
+      </div>
     </div>
 
-    <template v-for="filing in filings" :key="filing.filingId">
-      <Component
-        :is="filingComponent(filing)"
-        v-if="filing.displayLedger"
-        :filing="filing"
-        :downloading="downloading"
-      />
-    </template>
+    <!-- filings display after history is fetched -->
+    <template v-else>
+      <!-- Court order notification -->
+      <div
+        v-if="hasCourtOrders"
+        class="flex flex-row gap-2 w-full bg-white p-5 rounded mb-5 items-center"
+        data-cy="hasCourtOrdersNotificationCard"
+      >
+        <UIcon name="i-mdi-gavel" class="text-xl text-black" />
+        <span class="ml-1 text-base">{{ $t('text.filing.courtOrder.hasCourtOrders') }}</span>
+      </div>
 
-    <div v-if="filings.length === 0" class="flex flex-col w-full bg-white p-5 rounded">
-      <div v-if="!!currentBusiness" data-cy="business-filing-history-empty">
-        <div>
-          <strong>{{ $t('text.filing.youHaveNoFilingHistory') }}</strong>
+      <template v-for="filing in filings" :key="filing.filingId">
+        <Component
+          :is="filingComponent(filing)"
+          v-if="filing.displayLedger"
+          :filing="filing"
+          :downloading="downloading"
+        />
+      </template>
+
+      <div v-if="filings.length === 0" class="flex flex-col w-full bg-white p-5 rounded">
+        <div v-if="!!currentBusiness" data-cy="business-filing-history-empty">
+          <div>
+            <strong>{{ $t('text.filing.youHaveNoFilingHistory') }}</strong>
+          </div>
+          <div> {{ $t('text.filing.yourFilingsWillAppearHere') }}</div>
         </div>
-        <div> {{ $t('text.filing.yourFilingsWillAppearHere') }}</div>
+        <div v-else class="flex justify-center">
+          <span>{{ $t('text.filing.completeYourFiling') }}</span>
+        </div>
       </div>
-      <div v-else class="flex justify-center">
-        <span>{{ $t('text.filing.completeYourFiling') }}</span>
-      </div>
-    </div>
+    </template>
   </div>
 </template>

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -20,7 +20,7 @@ const { bootstrapFiling, bootstrapFilingType, bootstrapIdentifier, bootstrapLega
 
 const { todos } = storeToRefs(useBcrosTodos())
 const { getPendingCoa } = useBcrosFilings()
-const { filings } = storeToRefs(useBcrosFilings())
+const { filings, loading: filingsLoading } = storeToRefs(useBcrosFilings())
 const { pendingFilings } = storeToRefs(useBcrosBusinessBootstrap())
 const toast = useToast()
 const initialDateString = ref<Date | undefined>(undefined)
@@ -470,7 +470,12 @@ const coaEffectiveDate = computed(() => {
         <template #header>
           <div>
             {{ $t('title.section.filingHistory') }}
-            <span class="font-normal">({{ filings?.filter(f=>f.displayLedger).length || 0 }})</span>
+            <span v-if="filingsLoading" class="font-normal" data-cy="filing-history-count-loading">
+              (loading...)
+            </span>
+            <span v-else class="font-normal" data-cy="filing-history-count">
+              ({{ filings?.filter(f=>f.displayLedger).length || 0 }})
+            </span>
             <BcrosFilingAddStaffFiling
               v-if="isAuthorizedAddStaffFiling"
               class="float-right font-small overflow-auto"

--- a/src/stores/filings.ts
+++ b/src/stores/filings.ts
@@ -76,8 +76,17 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
   const loadFilings = async (identifier: string, force = false) => {
     const businessCached = (filings.value.length > 0)
     if (!businessCached || force) {
-      const newFilings = await getFilings(identifier)
-      filings.value.push(...newFilings)
+      loading.value = true
+      try {
+        const newFilings = await getFilings(identifier)
+        // replace existing filings so a forced reload doesn't duplicate rows,
+        // while preserving filings the API does not return here (i.e. pending task filings inserted by the todo store)
+        const fetchedIds = new Set(newFilings.map(filing => filing.filingId))
+        const preserved = filings.value.filter(filing => !fetchedIds.has(filing.filingId))
+        filings.value = [...preserved, ...newFilings]
+      } finally {
+        loading.value = false
+      }
     }
   }
 
@@ -86,7 +95,12 @@ export const useBcrosFilings = defineStore('bcros/filings', () => {
   }
 
   const insertFiling = (filing: ApiResponseFilingI) => {
-    filings.value.unshift(filing)
+    const existingIndex = filings.value.findIndex(existing => existing.filingId === filing.filingId)
+    if (existingIndex >= 0) {
+      filings.value.splice(existingIndex, 1, filing)
+    } else {
+      filings.value.unshift(filing)
+    }
   }
 
   const { isBaseCompany } = storeToRefs(useBcrosBusiness())

--- a/tests/components/bcros/BcrosFilingList.spec.ts
+++ b/tests/components/bcros/BcrosFilingList.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { mockedI18n } from '../../test-utils/mockedi18n'
+import { useBcrosFilings } from '../../../src/stores/filings'
+import { BcrosFilingList } from '#components'
+
+describe('BcrosFilingList loading state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  const mountList = () =>
+    mount(BcrosFilingList, { props: { filings: [] }, global: { plugins: [mockedI18n] } })
+
+  it('shows the loading skeletons and hides the empty state while filings are loading', () => {
+    useBcrosFilings().loading = true
+    const wrapper = mountList()
+
+    const loadingBlock = wrapper.find('[data-cy="filing-history-loading"]')
+    expect(loadingBlock.exists()).toBe(true)
+    // three skeleton placeholder cards
+    expect(loadingBlock.element.children.length).toBe(3)
+    expect(wrapper.text()).not.toContain('text.filing.completeYourFiling')
+
+    wrapper.unmount()
+  })
+
+  it('shows the empty state and no skeletons once loading completes', () => {
+    useBcrosFilings().loading = false
+    const wrapper = mountList()
+
+    expect(wrapper.find('[data-cy="filing-history-loading"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('text.filing.completeYourFiling')
+
+    wrapper.unmount()
+  })
+})

--- a/tests/pages/dashboard.spec.ts
+++ b/tests/pages/dashboard.spec.ts
@@ -5,6 +5,7 @@ import { mockedI18n } from '../test-utils/mockedi18n'
 import Dashboard from '../../src/pages/dashboard.vue'
 import { DefaultRoles } from '../test-utils'
 import { useBcrosAccount } from '../../src/stores/account'
+import { useBcrosFilings } from '../../src/stores/filings'
 
 describe('dashboard page tests', () => {
   let wrapper: VueWrapper<any>
@@ -21,5 +22,21 @@ describe('dashboard page tests', () => {
   it('renders search page with expected child components for public search', () => {
     // check header is there
     expect(wrapper.text()).toContain('title.section.filingHistory')
+  })
+
+  it('shows a loading label instead of the filing count while filings are loading', async () => {
+    const filings = useBcrosFilings()
+
+    filings.loading = true
+    await wrapper.vm.$nextTick()
+    const loadingLabel = wrapper.find('[data-cy="filing-history-count-loading"]')
+    expect(loadingLabel.exists()).toBe(true)
+    expect(loadingLabel.text()).toBe('(loading...)')
+    expect(wrapper.find('[data-cy="filing-history-count"]').exists()).toBe(false)
+
+    filings.loading = false
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-cy="filing-history-count-loading"]').exists()).toBe(false)
+    expect(wrapper.find('[data-cy="filing-history-count"]').exists()).toBe(true)
   })
 })

--- a/tests/stores/filings.spec.ts
+++ b/tests/stores/filings.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+import type { ApiResponseFilingI } from '../../src/interfaces/filing-i'
+import { useBcrosFilings } from '../../src/stores/filings'
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }))
+
+vi.mock('~/composables/useBcrosLegalApi', () => ({
+  useBcrosLegalApi: () => ({
+    getConfig: () => ({ apiURL: 'https://legal-api.example.com/api/v2' }),
+    fetch: mockFetch
+  })
+}))
+
+/** Builds a minimal filing exposing only the fields the store reads. */
+const buildFiling = (filingId: number, overrides: Partial<ApiResponseFilingI> = {}): ApiResponseFilingI =>
+  ({
+    filingId,
+    businessIdentifier: 'BC1234567',
+    displayLedger: true,
+    name: 'changeOfDirectors',
+    status: 'COMPLETED',
+    ...overrides
+  } as unknown as ApiResponseFilingI)
+
+/** Mocks the legal-api fetch to resolve with the given filings. */
+const mockFilingsResponse = (filings: Array<ApiResponseFilingI>) => {
+  mockFetch.mockResolvedValue({ data: ref({ filings }), error: ref(null) })
+}
+
+describe('filings store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockFetch.mockReset()
+  })
+
+  it('populates filings on initial load', async () => {
+    mockFilingsResponse([buildFiling(1), buildFiling(2)])
+    const store = useBcrosFilings()
+
+    await store.loadFilings('BC1234567')
+
+    expect(store.filings.map(f => f.filingId)).toEqual([1, 2])
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the fetch when filings are cached and force is not set', async () => {
+    mockFilingsResponse([buildFiling(1)])
+    const store = useBcrosFilings()
+
+    await store.loadFilings('BC1234567')
+    await store.loadFilings('BC1234567')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not duplicate filings on a forced reload', async () => {
+    mockFilingsResponse([buildFiling(1), buildFiling(2)])
+    const store = useBcrosFilings()
+
+    await store.loadFilings('BC1234567')
+    await store.loadFilings('BC1234567', true)
+
+    expect(store.filings.map(f => f.filingId)).toEqual([1, 2])
+  })
+
+  it('preserves task-derived filings absent from the API response on a forced reload', async () => {
+    mockFilingsResponse([buildFiling(1), buildFiling(2)])
+    const store = useBcrosFilings()
+
+    await store.loadFilings('BC1234567')
+    // a pending payment-completed maintenance filing inserted by the todo store
+    store.insertFiling(buildFiling(99, { status: 'PENDING' }))
+    await store.loadFilings('BC1234567', true)
+
+    expect(store.filings.map(f => f.filingId)).toEqual([99, 1, 2])
+  })
+
+  it('replaces a task-derived filing that now appears in the API response', async () => {
+    mockFilingsResponse([buildFiling(1)])
+    const store = useBcrosFilings()
+
+    await store.loadFilings('BC1234567')
+    store.insertFiling(buildFiling(99, { status: 'PENDING' }))
+    // the pending filing has since completed and is now in the ledger response
+    mockFilingsResponse([buildFiling(1), buildFiling(99, { status: 'COMPLETED' })])
+    await store.loadFilings('BC1234567', true)
+
+    expect(store.filings.map(f => f.filingId)).toEqual([1, 99])
+    expect(store.filings.find(f => f.filingId === 99).status).toBe('COMPLETED')
+  })
+
+  it('inserts the same filing only once, updating it in place', () => {
+    const store = useBcrosFilings()
+
+    store.insertFiling(buildFiling(99, { status: 'PENDING' }))
+    store.insertFiling(buildFiling(99, { status: 'PAID' }))
+
+    expect(store.filings).toHaveLength(1)
+    expect(store.filings[0].status).toBe('PAID')
+  })
+
+  it('sets loading while the fetch is in flight', async () => {
+    let resolveFetch: (value: unknown) => void
+    mockFetch.mockReturnValue(new Promise((resolve) => { resolveFetch = resolve }))
+    const store = useBcrosFilings()
+
+    const load = store.loadFilings('BC1234567')
+    expect(store.loading).toBe(true)
+
+    resolveFetch({ data: ref({ filings: [buildFiling(1)] }), error: ref(null) })
+    await load
+
+    expect(store.loading).toBe(false)
+    expect(store.filings).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/34065

*Description of changes:*
- prevents duplicate filings getting added when staff do a filing via the staff filing modal (you can duplicate this bug in dev/test by doing an admin dissolution or put back on)
- also addresses filing history loading issue (used to show business having no filings until API resp returned)
  - UX has seen this change for the loading state of the filing history and said its okay
  - loading state:
<img width="1807" height="915" alt="business-dashboard-loading" src="https://github.com/user-attachments/assets/bdd3e175-56e4-4afb-bdf5-cdee76cfaa91" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
